### PR TITLE
Split lessons into separate module pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
       outline: none;
     }
 
-    .module-link.is-current {
+    .module-link[aria-current="page"] {
       background: rgba(139, 92, 246, 0.32);
       color: white;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
@@ -253,39 +253,6 @@
       outline: none;
     }
 
-    @media (max-width: 720px) {
-      .lesson-nav {
-        justify-content: center;
-        text-align: center;
-      }
-
-      .module-links {
-        justify-content: center;
-      }
-
-      .menu {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-      }
-
-      .menu-panel {
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-      }
-    }
-
-    @media (prefers-color-scheme: dark) {
-      nav {
-        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
-      }
-
-      footer p {
-        background: rgba(30, 17, 52, 0.62);
-      }
-    }
-
     main {
       padding: 3rem 1.5rem 4.5rem;
       max-width: 1100px;
@@ -310,14 +277,6 @@
       margin-bottom: 0.75rem;
     }
 
-    h3 {
-      color: var(--muted);
-      margin-bottom: 0.6rem;
-      font-size: 1.05rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
     p {
       margin: 0.6rem 0;
     }
@@ -330,24 +289,6 @@
 
     li {
       margin-bottom: 0.45rem;
-    }
-
-    .module-card .module-lessons {
-      list-style: none;
-      margin: 1.1rem 0 1.6rem;
-      padding: 0;
-      display: grid;
-      gap: 0.5rem;
-    }
-
-    .module-card .module-lessons li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.55);
-      padding: 0.75rem 1rem;
-      border-radius: 16px;
-      font-weight: 600;
-      color: var(--accent-strong);
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
     }
 
     .examples {
@@ -378,27 +319,64 @@
       box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.12);
     }
 
-    .module-cta {
+    .module-card {
+      display: grid;
+      gap: 1.1rem;
+    }
+
+    .module-card p {
+      margin: 0;
+    }
+
+    .module-lessons {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .module-lessons a {
+      text-decoration: none;
+      color: inherit;
+      font-weight: 600;
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      padding: 0.75rem 1.4rem;
-      border-radius: 999px;
-      background: linear-gradient(135deg, rgba(139, 92, 246, 0.9), rgba(56, 189, 248, 0.75));
-      color: white;
+    }
+
+    .module-lessons a::before {
+      content: "→";
+      color: var(--accent-strong);
+      font-weight: 700;
+    }
+
+    .module-card-link {
+      justify-self: start;
       text-decoration: none;
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.85), rgba(56, 189, 248, 0.75));
+      color: white;
       font-weight: 600;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+      padding: 0.85rem 1.4rem;
+      border-radius: 999px;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .module-cta:hover,
-    .module-cta:focus-visible {
+    .module-card-link:hover,
+    .module-card-link:focus-visible {
       transform: translateY(-2px);
       box-shadow: 0 22px 40px rgba(80, 56, 160, 0.36);
       outline: none;
+    }
+
+    .module-card small {
+      color: var(--muted);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
 
     footer {
@@ -420,33 +398,70 @@
       backdrop-filter: blur(16px);
       box-shadow: 0 12px 30px var(--shadow);
     }
+
+    @media (max-width: 720px) {
+      .lesson-nav {
+        justify-content: center;
+      }
+
+      .module-links {
+        justify-content: center;
+      }
+
+      .menu {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+      }
+
+      .menu-panel {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+      }
+
+      .module-card-link {
+        justify-self: center;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      nav {
+        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
+      }
+
+      footer p {
+        background: rgba(30, 17, 52, 0.62);
+      }
+    }
   </style>
 </head>
 <body>
   <header>
     <h1>Grammaire Martiniquaise</h1>
-    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en leçons pour accompagner vos exercices et révisions.</p>
+    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en modules thématiques pour accomp
+agner vos exercices et révisions.</p>
   </header>
 
-  <nav aria-label="Navigation des leçons">
+  <nav aria-label="Navigation principale">
     <div class="lesson-nav">
-      <div class="module-links" role="list">
-        <a class="module-link is-current" href="index.html" role="listitem" aria-current="page">Sommaire</a>
-        <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
-        <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
-        <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
-        <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
+      <div class="module-links">
+        <a class="module-link" href="index.html" aria-current="page">Accueil</a>
+        <a class="module-link" href="module-1.html">Module 1</a>
+        <a class="module-link" href="module-2.html">Module 2</a>
+        <a class="module-link" href="module-3.html">Module 3</a>
+        <a class="module-link" href="module-4.html">Module 4</a>
       </div>
       <details class="menu">
-        <summary class="menu-toggle">
-          Sommaire des modules
+        <summary class="menu-toggle" aria-expanded="false">
+          Sommaire
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Explorer les modules</p>
+            <p class="menu-group-title">Sur cette page</p>
             <ul>
               <li><a href="#module-1">Module 1 · Déterminants et interactions</a></li>
               <li><a href="#module-2">Module 2 · Prépositions et expressions</a></li>
@@ -461,100 +476,121 @@
 
   <main>
     <section class="module-card" id="module-1">
-      <h2>Module 1 · Déterminants et interactions</h2>
-      <p>Approfondissez l’usage des déterminants, pronoms et outils interrogatifs essentiels du créole martiniquais.</p>
+      <small>Module 1</small>
+      <h2>Déterminants et interactions</h2>
+      <p>Articles, pronoms et particules interrogatives ouvrent l’étude par les fondations du syntagme nominal et des relations
+ entre les mots.</p>
       <ul class="module-lessons">
-        <li>L’article défini</li>
-        <li>L’article indéfini</li>
-        <li>Le pluriel</li>
-        <li>Les pronoms personnels</li>
-        <li>Les possessifs</li>
-        <li>Les démonstratifs</li>
-        <li>Les relatifs</li>
-        <li>L’interrogation</li>
-        <li>La négation</li>
+        <li><a href="module-1.html#lesson-1">L’article défini</a></li>
+        <li><a href="module-1.html#lesson-2">L’article indéfini</a></li>
+        <li><a href="module-1.html#lesson-3">Le pluriel</a></li>
+        <li><a href="module-1.html#lesson-4">Les pronoms personnels</a></li>
+        <li><a href="module-1.html#lesson-5">Les possessifs</a></li>
+        <li><a href="module-1.html#lesson-6">Les démonstratifs</a></li>
+        <li><a href="module-1.html#lesson-7">Les relatifs</a></li>
+        <li><a href="module-1.html#lesson-8">L’interrogation</a></li>
+        <li><a href="module-1.html#lesson-9">La négation</a></li>
       </ul>
-      <a class="module-cta" href="module-1.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <a class="module-card-link" href="module-1.html">Accéder au module 1</a>
     </section>
 
     <section class="module-card" id="module-2">
-      <h2>Module 2 · Prépositions et expressions</h2>
-      <p>Explorez les principales particules prépositionnelles et exclamatives pour gagner en fluidité dans vos échanges.</p>
+      <small>Module 2</small>
+      <h2>Prépositions et expressions</h2>
+      <p>Ce module rassemble les particules qui expriment l’exclamation, les nuances de lieu, de destination et les relations log
+iques entre les éléments de la phrase.</p>
       <ul class="module-lessons">
-        <li>L’exclamation</li>
-        <li>La préposition « à »</li>
-        <li>La préposition « de »</li>
-        <li>Autres prépositions (I)</li>
-        <li>Autres prépositions (II)</li>
+        <li><a href="module-2.html#lesson-10">L’exclamation</a></li>
+        <li><a href="module-2.html#lesson-11">La préposition « à »</a></li>
+        <li><a href="module-2.html#lesson-12">La préposition « de »</a></li>
+        <li><a href="module-2.html#lesson-13">Autres prépositions (I)</a></li>
+        <li><a href="module-2.html#lesson-14">Autres prépositions (II)</a></li>
       </ul>
-      <a class="module-cta" href="module-2.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <a class="module-card-link" href="module-2.html">Accéder au module 2</a>
     </section>
 
     <section class="module-card" id="module-3">
-      <h2>Module 3 · Verbe et temps</h2>
-      <p>Maîtrisez les valeurs temporelles et aspectuelles en contexte : être, temps simples, conditionnel ou impératif.</p>
+      <small>Module 3</small>
+      <h2>Verbe et temps</h2>
+      <p>Le cœur verbal est exploré à travers les principales particules temporelles, l’expression de la condition et des modalit
+és, ainsi que les constructions impératives.</p>
       <ul class="module-lessons">
-        <li>Le verbe « être »</li>
-        <li>Présent et particule « ka »</li>
-        <li>Le passé</li>
-        <li>Futur et conditionnel</li>
-        <li>La phrase conditionnelle</li>
-        <li>L’impératif</li>
-        <li>Le passif</li>
-        <li>Les verbes composés</li>
-        <li>Obligation et probabilité</li>
-        <li>Le verbe « pouvoir »</li>
+        <li><a href="module-3.html#lesson-15">Le verbe « être »</a></li>
+        <li><a href="module-3.html#lesson-16">Présent et particule « ka »</a></li>
+        <li><a href="module-3.html#lesson-17">Le passé</a></li>
+        <li><a href="module-3.html#lesson-18">Futur et conditionnel</a></li>
+        <li><a href="module-3.html#lesson-19">La phrase conditionnelle</a></li>
+        <li><a href="module-3.html#lesson-20">L’impératif</a></li>
+        <li><a href="module-3.html#lesson-21">Le passif</a></li>
+        <li><a href="module-3.html#lesson-22">Les verbes composés</a></li>
+        <li><a href="module-3.html#lesson-23">Obligation et probabilité</a></li>
+        <li><a href="module-3.html#lesson-24">Le verbe « pouvoir »</a></li>
       </ul>
-      <a class="module-cta" href="module-3.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <a class="module-card-link" href="module-3.html">Accéder au module 3</a>
     </section>
 
     <section class="module-card" id="module-4">
-      <h2>Module 4 · Structures nominales et quantification</h2>
-      <p>Consolidez la construction du nom et la quantification pour nuancer descriptions et comparaisons.</p>
+      <small>Module 4</small>
+      <h2>Structures nominales et quantification</h2>
+      <p>Les derniers chapitres couvrent l’organisation du groupe nominal, l’adjectif, les degrés de comparaison et les outils de
+ quantification.</p>
       <ul class="module-lessons">
-        <li>Les usages de « sé »</li>
-        <li>Le nom commun</li>
-        <li>Noms propres, titres et adresses</li>
-        <li>L’adjectif</li>
-        <li>Le comparatif</li>
-        <li>Le superlatif</li>
-        <li>Quantification et numération (I)</li>
-        <li>Quantification et numération (II)</li>
+        <li><a href="module-4.html#lesson-25">Les usages de « sé »</a></li>
+        <li><a href="module-4.html#lesson-26">Le nom commun</a></li>
+        <li><a href="module-4.html#lesson-27">Noms propres, titres et adresses</a></li>
+        <li><a href="module-4.html#lesson-28">L’adjectif</a></li>
+        <li><a href="module-4.html#lesson-29">Le comparatif</a></li>
+        <li><a href="module-4.html#lesson-30">Le superlatif</a></li>
+        <li><a href="module-4.html#lesson-31">Quantification et numération (I)</a></li>
+        <li><a href="module-4.html#lesson-32">Quantification et numération (II)</a></li>
       </ul>
-      <a class="module-cta" href="module-4.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <a class="module-card-link" href="module-4.html">Accéder au module 4</a>
     </section>
   </main>
 
   <footer>
-    <p>Mise à jour des règles grammaticales pour accompagner les exercices de créole martiniquais.</p>
+    <p>Travail collaboratif · Merci à tou·te·s les contributrices et contributeurs !</p>
   </footer>
 
   <script>
-    const menu = document.querySelector('.menu');
+    const menus = document.querySelectorAll('details.menu');
 
-    if (menu) {
-      const panel = menu.querySelector('.menu-panel');
+    menus.forEach((menu) => {
+      const summary = menu.querySelector('summary');
+      const links = menu.querySelectorAll('a');
 
-      panel?.addEventListener('click', (event) => {
-        const link = event.target.closest('a');
-        if (link) {
+      if (summary) {
+        summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        menu.addEventListener('toggle', () => {
+          summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        });
+      }
+
+      links.forEach((link) => {
+        link.addEventListener('click', () => {
           menu.removeAttribute('open');
-        }
+        });
       });
+    });
 
-      document.addEventListener('click', (event) => {
+    document.addEventListener('click', (event) => {
+      menus.forEach((menu) => {
         if (!menu.contains(event.target)) {
           menu.removeAttribute('open');
         }
       });
+    });
 
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-          menu.removeAttribute('open');
-          menu.querySelector('summary')?.focus();
-        }
-      });
-    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        menus.forEach((menu) => {
+          if (menu.open) {
+            menu.removeAttribute('open');
+            menu.querySelector('summary')?.focus();
+          }
+        });
+      }
+    });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     header {
       background: linear-gradient(140deg, rgba(139, 92, 246, 0.95), rgba(56, 189, 248, 0.85));
       color: white;
-      padding: 3.5rem 1.5rem 2.25rem;
+      padding: 3.5rem 1.5rem 3.25rem;
       text-align: center;
       position: relative;
       overflow: hidden;
@@ -68,15 +68,49 @@
       z-index: 1;
     }
 
-    header h1 {
-      margin: 0;
-      font-size: clamp(2rem, 5vw, 3rem);
+    .hero-content {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
     }
 
-    header p {
-      margin: 0.75rem auto 0;
-      max-width: 60ch;
-      font-size: 1.1rem;
+    header h1 {
+      margin: 0;
+      font-size: clamp(2rem, 5vw, 3.4rem);
+    }
+
+    .hero-tagline {
+      margin: 0;
+      font-size: clamp(1.05rem, 2.4vw, 1.3rem);
+      max-width: 70ch;
+    }
+
+    .cta-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.6rem;
+      padding: 0.95rem 2.2rem;
+      border-radius: 999px;
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.05));
+      color: white;
+      text-decoration: none;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      box-shadow: 0 22px 45px rgba(80, 56, 160, 0.45);
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    }
+
+    .cta-button:hover,
+    .cta-button:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 26px 55px rgba(80, 56, 160, 0.6);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.15));
+      outline: none;
     }
 
     nav {
@@ -281,51 +315,156 @@
       margin: 0.6rem 0;
     }
 
-    ul,
-    ol {
-      margin: 0.75rem 0 0.75rem 1.25rem;
-      padding: 0;
+    .section-lead {
+      font-size: 1.05rem;
+      margin-bottom: 1.5rem;
     }
 
-    li {
-      margin-bottom: 0.45rem;
-    }
-
-    .examples {
+    .feature-grid,
+    .audience-grid,
+    .testimonial-grid,
+    .pricing-table {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.25rem;
+    }
+
+    .feature-card,
+    .audience-card,
+    .testimonial-card,
+    .pricing-card {
+      border-radius: 20px;
+      padding: 1.5rem;
+      background: rgba(255, 255, 255, 0.32);
+      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.14);
+      backdrop-filter: blur(14px);
+    }
+
+    .feature-card p,
+    .audience-card p {
+      margin-bottom: 0;
+    }
+
+    .story-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .testimonial-card blockquote {
+      margin: 0;
+      font-size: 1.05rem;
+      line-height: 1.7;
+      color: var(--fg);
+    }
+
+    .testimonial-card figcaption {
+      margin-top: 1rem;
+      font-weight: 600;
+      color: var(--accent-strong);
+    }
+
+    .faq-list {
+      display: grid;
       gap: 0.75rem;
-      margin: 1rem 0;
-      padding: 0;
+    }
+
+    .faq-list details {
+      background: rgba(255, 255, 255, 0.3);
+      border-radius: 18px;
+      padding: 1rem 1.2rem;
+      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.12);
+      backdrop-filter: blur(10px);
+    }
+
+    .faq-list summary {
+      cursor: pointer;
+      font-weight: 600;
+      color: var(--accent-strong);
       list-style: none;
     }
 
-    .examples li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.85);
-      padding: 0.9rem 1.1rem;
-      border-radius: 14px;
-      margin: 0;
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
+    .faq-list summary::-webkit-details-marker {
+      display: none;
     }
 
-    .note {
-      background: rgba(250, 204, 21, 0.18);
-      border-left: 4px solid #facc15;
-      padding: 0.85rem 1.1rem;
-      border-radius: 14px;
-      margin: 1.2rem 0;
-      color: inherit;
-      box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.12);
+    .faq-list details[open] summary {
+      margin-bottom: 0.6rem;
+    }
+
+    .pricing-card {
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+      align-items: flex-start;
+    }
+
+    .pricing-card.highlight {
+      background: rgba(139, 92, 246, 0.28);
+      box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.4);
+    }
+
+    .pricing-card ul {
+      margin: 0;
+      padding-left: 1.2rem;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .price {
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: var(--accent-strong);
+      margin: 0;
+    }
+
+    .secondary-cta {
+      margin-top: auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.65rem 1.4rem;
+      border-radius: 999px;
+      text-decoration: none;
+      font-weight: 600;
+      color: var(--accent-strong);
+      background: rgba(255, 255, 255, 0.6);
+      box-shadow: 0 14px 28px rgba(80, 56, 160, 0.18);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .secondary-cta:hover,
+    .secondary-cta:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 18px 36px rgba(80, 56, 160, 0.28);
+      outline: none;
+    }
+
+    .module-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
     }
 
     .module-card {
       display: grid;
       gap: 1.1rem;
+      background: var(--surface);
+      border-radius: 26px;
+      padding: clamp(1.75rem, 2.4vw, 2.65rem);
+      box-shadow: 0 20px 55px var(--shadow);
+      border: 1px solid var(--surface-strong);
+      backdrop-filter: blur(18px);
     }
 
     .module-card p {
       margin: 0;
+    }
+
+    .module-card h3 {
+      margin: 0;
+      color: var(--accent-strong);
+      font-size: clamp(1.45rem, 2.6vw, 1.9rem);
     }
 
     .module-lessons {
@@ -384,9 +523,12 @@
       padding: 2.5rem 1.5rem 3.5rem;
       color: var(--muted);
       font-size: 0.95rem;
+      display: grid;
+      gap: 1.2rem;
+      justify-items: center;
     }
 
-    footer p {
+    .footer-pill {
       margin: 0;
       display: inline-flex;
       align-items: center;
@@ -397,6 +539,12 @@
       border: 1px solid var(--surface-strong);
       backdrop-filter: blur(16px);
       box-shadow: 0 12px 30px var(--shadow);
+    }
+
+    .footer-note {
+      margin: 0;
+      font-weight: 600;
+      letter-spacing: 0.02em;
     }
 
     @media (max-width: 720px) {
@@ -430,17 +578,38 @@
         background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
       }
 
-      footer p {
+      .footer-pill {
         background: rgba(30, 17, 52, 0.62);
+      }
+
+      .feature-card,
+      .audience-card,
+      .testimonial-card,
+      .pricing-card {
+        background: rgba(15, 7, 28, 0.56);
+      }
+
+      .faq-list details {
+        background: rgba(15, 7, 28, 0.6);
+      }
+
+      .secondary-cta {
+        background: rgba(15, 7, 28, 0.75);
+      }
+
+      .footer-note {
+        color: rgba(184, 176, 214, 0.85);
       }
     }
   </style>
 </head>
 <body>
   <header>
-    <h1>Grammaire Martiniquaise</h1>
-    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en modules thématiques pour accomp
-agner vos exercices et révisions.</p>
+    <div class="hero-content">
+      <h1>Grammaire Martiniquaise</h1>
+      <p class="hero-tagline">La plateforme qui facilite l’apprentissage du créole martiniquais grâce à des ressources structurées, des parcours guidés et des outils pensés pour la pratique quotidienne.</p>
+      <a class="cta-button" href="/paiement">S’abonner</a>
+    </div>
   </header>
 
   <nav aria-label="Navigation principale">
@@ -461,7 +630,18 @@ agner vos exercices et révisions.</p>
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Sur cette page</p>
+            <p class="menu-group-title">Explorer l’offre</p>
+            <ul>
+              <li><a href="#presentation">Présentation du service</a></li>
+              <li><a href="#audience">Public visé</a></li>
+              <li><a href="#genese">Genèse du projet</a></li>
+              <li><a href="#social-proof">Preuves sociales</a></li>
+              <li><a href="#faq">FAQ</a></li>
+              <li><a href="#pricing">Formules et tarifs</a></li>
+            </ul>
+          </div>
+          <div class="menu-group">
+            <p class="menu-group-title">Modules de grammaire</p>
             <ul>
               <li><a href="#module-1">Module 1 · Déterminants et interactions</a></li>
               <li><a href="#module-2">Module 2 · Prépositions et expressions</a></li>
@@ -475,81 +655,206 @@ agner vos exercices et révisions.</p>
   </nav>
 
   <main>
-    <section class="module-card" id="module-1">
-      <small>Module 1</small>
-      <h2>Déterminants et interactions</h2>
-      <p>Articles, pronoms et particules interrogatives ouvrent l’étude par les fondations du syntagme nominal et des relations
- entre les mots.</p>
-      <ul class="module-lessons">
-        <li><a href="module-1.html#lesson-1">L’article défini</a></li>
-        <li><a href="module-1.html#lesson-2">L’article indéfini</a></li>
-        <li><a href="module-1.html#lesson-3">Le pluriel</a></li>
-        <li><a href="module-1.html#lesson-4">Les pronoms personnels</a></li>
-        <li><a href="module-1.html#lesson-5">Les possessifs</a></li>
-        <li><a href="module-1.html#lesson-6">Les démonstratifs</a></li>
-        <li><a href="module-1.html#lesson-7">Les relatifs</a></li>
-        <li><a href="module-1.html#lesson-8">L’interrogation</a></li>
-        <li><a href="module-1.html#lesson-9">La négation</a></li>
-      </ul>
-      <a class="module-card-link" href="module-1.html">Accéder au module 1</a>
+    <section id="presentation">
+      <h2>Présentation du service</h2>
+      <p class="section-lead">Kreyolang est un service d’accompagnement numérique pour apprendre et pratiquer le créole martiniquais. Il combine des parcours guidés, des ressources audio et écrites, ainsi qu’un suivi continu pour aider les apprenant·es à progresser avec confiance.</p>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <h3>Parcours progressifs</h3>
+          <p>Des modules thématiques conçus avec des linguistes et des enseignants pour maîtriser les bases avant d’aller vers la conversation spontanée.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Pratique quotidienne</h3>
+          <p>Des exercices interactifs, des capsules audio et des rappels personnalisés pour maintenir le rythme même avec un agenda chargé.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Support communautaire</h3>
+          <p>Un accès à un forum modéré, à des ateliers en direct et à des feedbacks ciblés pour ne jamais apprendre seul·e.</p>
+        </article>
+      </div>
     </section>
 
-    <section class="module-card" id="module-2">
-      <small>Module 2</small>
-      <h2>Prépositions et expressions</h2>
-      <p>Ce module rassemble les particules qui expriment l’exclamation, les nuances de lieu, de destination et les relations log
-iques entre les éléments de la phrase.</p>
-      <ul class="module-lessons">
-        <li><a href="module-2.html#lesson-10">L’exclamation</a></li>
-        <li><a href="module-2.html#lesson-11">La préposition « à »</a></li>
-        <li><a href="module-2.html#lesson-12">La préposition « de »</a></li>
-        <li><a href="module-2.html#lesson-13">Autres prépositions (I)</a></li>
-        <li><a href="module-2.html#lesson-14">Autres prépositions (II)</a></li>
-      </ul>
-      <a class="module-card-link" href="module-2.html">Accéder au module 2</a>
+    <section id="audience">
+      <h2>Public visé</h2>
+      <div class="audience-grid">
+        <article class="audience-card">
+          <h3>Débutant·es curieux·ses</h3>
+          <p>Vous souhaitez découvrir la richesse du créole martiniquais sans savoir par où commencer ? Les parcours guidés proposent une progression sécurisante.</p>
+        </article>
+        <article class="audience-card">
+          <h3>Familles et diasporas</h3>
+          <p>Retissez le lien avec vos racines linguistiques grâce à des contenus culturels authentiques et des activités à réaliser en famille.</p>
+        </article>
+        <article class="audience-card">
+          <h3>Professionnel·les de terrain</h3>
+          <p>Enrichissez votre communication au quotidien avec des lexiques métiers, des mises en situation et des modules dédiés à la médiation linguistique.</p>
+        </article>
+      </div>
     </section>
 
-    <section class="module-card" id="module-3">
-      <small>Module 3</small>
-      <h2>Verbe et temps</h2>
-      <p>Le cœur verbal est exploré à travers les principales particules temporelles, l’expression de la condition et des modalit
-és, ainsi que les constructions impératives.</p>
-      <ul class="module-lessons">
-        <li><a href="module-3.html#lesson-15">Le verbe « être »</a></li>
-        <li><a href="module-3.html#lesson-16">Présent et particule « ka »</a></li>
-        <li><a href="module-3.html#lesson-17">Le passé</a></li>
-        <li><a href="module-3.html#lesson-18">Futur et conditionnel</a></li>
-        <li><a href="module-3.html#lesson-19">La phrase conditionnelle</a></li>
-        <li><a href="module-3.html#lesson-20">L’impératif</a></li>
-        <li><a href="module-3.html#lesson-21">Le passif</a></li>
-        <li><a href="module-3.html#lesson-22">Les verbes composés</a></li>
-        <li><a href="module-3.html#lesson-23">Obligation et probabilité</a></li>
-        <li><a href="module-3.html#lesson-24">Le verbe « pouvoir »</a></li>
-      </ul>
-      <a class="module-card-link" href="module-3.html">Accéder au module 3</a>
+    <section id="genese">
+      <h2>Genèse du projet</h2>
+      <div class="story-grid">
+        <p>Kreyolang est né d’un collectif d’enseignant·es et de locuteur·rices natifs désireux de rendre l’apprentissage du créole martiniquais accessible partout. Après plusieurs années de rencontres dans les associations culturelles de l’île et de la diaspora, nous avons co-construit un parcours numérique qui restitue la richesse orale tout en proposant une progression claire.</p>
+        <p>La plateforme s’appuie sur des corpus authentiques recueillis auprès de conteurs, de musicien·nes et de familles, et sur une méthodologie testée dans des ateliers pilotes. Chaque trimestre, nous intégrons de nouvelles ressources issues de partenariats locaux (écoles, bibliothèques, radios) pour maintenir un lien vivant avec le territoire.</p>
+      </div>
     </section>
 
-    <section class="module-card" id="module-4">
-      <small>Module 4</small>
-      <h2>Structures nominales et quantification</h2>
-      <p>Les derniers chapitres couvrent l’organisation du groupe nominal, l’adjectif, les degrés de comparaison et les outils de
- quantification.</p>
-      <ul class="module-lessons">
-        <li><a href="module-4.html#lesson-25">Les usages de « sé »</a></li>
-        <li><a href="module-4.html#lesson-26">Le nom commun</a></li>
-        <li><a href="module-4.html#lesson-27">Noms propres, titres et adresses</a></li>
-        <li><a href="module-4.html#lesson-28">L’adjectif</a></li>
-        <li><a href="module-4.html#lesson-29">Le comparatif</a></li>
-        <li><a href="module-4.html#lesson-30">Le superlatif</a></li>
-        <li><a href="module-4.html#lesson-31">Quantification et numération (I)</a></li>
-        <li><a href="module-4.html#lesson-32">Quantification et numération (II)</a></li>
-      </ul>
-      <a class="module-card-link" href="module-4.html">Accéder au module 4</a>
+    <section id="social-proof">
+      <h2>Preuves sociales</h2>
+      <div class="testimonial-grid">
+        <figure class="testimonial-card">
+          <blockquote>« J’ai pu transmettre à mes enfants les expressions de mon enfance. Les parcours sont motivants et les rappels m’aident à garder le rythme. »</blockquote>
+          <figcaption>— Mireille, abonnée depuis 8 mois</figcaption>
+        </figure>
+        <figure class="testimonial-card">
+          <blockquote>« Les ateliers en direct ont complètement débloqué mon oral. On échange avec des personnes bienveillantes et on se sent soutenu. »</blockquote>
+          <figcaption>— Johan, apprenant intermédiaire</figcaption>
+        </figure>
+        <figure class="testimonial-card">
+          <blockquote>« En tant qu’enseignante, je recommande Kreyolang : les ressources sont fiables et actualisées, et mes élèves adorent les quiz. »</blockquote>
+          <figcaption>— Ségolène, professeure de collège</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section id="faq">
+      <h2>FAQ</h2>
+      <div class="faq-list">
+        <details>
+          <summary>Comment se déroule l’abonnement ?</summary>
+          <p>Une fois inscrit·e, vous accédez immédiatement à l’ensemble des parcours et vous recevez un plan de progression personnalisé. Le prélèvement est mensuel et résiliable en un clic.</p>
+        </details>
+        <details>
+          <summary>Dois-je déjà connaître le créole martiniquais ?</summary>
+          <p>Non, des parcours « découverte » permettent de démarrer sans prérequis. Vous pouvez ensuite passer aux modules intermédiaires et avancés quand vous vous sentez prêt·e.</p>
+        </details>
+        <details>
+          <summary>Proposez-vous des ressources pour les classes ou associations ?</summary>
+          <p>Oui, la formule « Collectivités » inclut des licences multi-utilisateurs, des guides pédagogiques et un accompagnement pour les animateur·rices.</p>
+        </details>
+        <details>
+          <summary>Puis-je tester la plateforme avant de payer ?</summary>
+          <p>Chaque nouvelle inscription bénéficie de 14 jours d’essai gratuit et d’un parcours d’initiation guidé pour découvrir les fonctionnalités sans engagement.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="pricing">
+      <h2>Tableau des formules</h2>
+      <div class="pricing-table">
+        <article class="pricing-card">
+          <h3>Découverte</h3>
+          <p class="price">12 € / mois</p>
+          <ul>
+            <li>Accès aux parcours débutants</li>
+            <li>Exercices quotidiens et rappels</li>
+            <li>Suivi de progression individuel</li>
+          </ul>
+          <a class="secondary-cta" href="/paiement">Choisir cette formule</a>
+        </article>
+        <article class="pricing-card highlight">
+          <h3>Intégrale</h3>
+          <p class="price">24 € / mois</p>
+          <ul>
+            <li>Tous les parcours et ateliers en direct</li>
+            <li>Capsules audio et vidéo exclusives</li>
+            <li>Corrections personnalisées hebdomadaires</li>
+          </ul>
+          <a class="secondary-cta" href="/paiement">Choisir cette formule</a>
+        </article>
+        <article class="pricing-card">
+          <h3>Collectivités</h3>
+          <p class="price">Sur devis</p>
+          <ul>
+            <li>Licences multi-utilisateurs illimitées</li>
+            <li>Formation des animateur·rices</li>
+            <li>Support dédié et ressources pédagogiques</li>
+          </ul>
+          <a class="secondary-cta" href="/paiement">Nous contacter</a>
+        </article>
+      </div>
+    </section>
+
+    <section id="modules">
+      <h2>Parcours de grammaire</h2>
+      <p class="section-lead">Retrouvez l’intégralité des 32 leçons réparties en quatre modules thématiques. Chaque page rassemble les contenus d’origine, leurs exemples et les encadrés de notes.</p>
+      <div class="module-grid">
+        <article class="module-card" id="module-1">
+          <small>Module 1</small>
+          <h3>Déterminants et interactions</h3>
+          <p>Articles, pronoms et particules interrogatives ouvrent l’étude par les fondations du syntagme nominal et des relations entre les mots.</p>
+          <ul class="module-lessons">
+            <li><a href="module-1.html#lesson-1">L’article défini</a></li>
+            <li><a href="module-1.html#lesson-2">L’article indéfini</a></li>
+            <li><a href="module-1.html#lesson-3">Le pluriel</a></li>
+            <li><a href="module-1.html#lesson-4">Les pronoms personnels</a></li>
+            <li><a href="module-1.html#lesson-5">Les possessifs</a></li>
+            <li><a href="module-1.html#lesson-6">Les démonstratifs</a></li>
+            <li><a href="module-1.html#lesson-7">Les relatifs</a></li>
+            <li><a href="module-1.html#lesson-8">L’interrogation</a></li>
+            <li><a href="module-1.html#lesson-9">La négation</a></li>
+          </ul>
+          <a class="module-card-link" href="module-1.html">Accéder au module 1</a>
+        </article>
+
+        <article class="module-card" id="module-2">
+          <small>Module 2</small>
+          <h3>Prépositions et expressions</h3>
+          <p>Ce module rassemble les particules qui expriment l’exclamation, les nuances de lieu, de destination et les relations logiques entre les éléments de la phrase.</p>
+          <ul class="module-lessons">
+            <li><a href="module-2.html#lesson-10">L’exclamation</a></li>
+            <li><a href="module-2.html#lesson-11">La préposition « à »</a></li>
+            <li><a href="module-2.html#lesson-12">La préposition « de »</a></li>
+            <li><a href="module-2.html#lesson-13">Autres prépositions (I)</a></li>
+            <li><a href="module-2.html#lesson-14">Autres prépositions (II)</a></li>
+          </ul>
+          <a class="module-card-link" href="module-2.html">Accéder au module 2</a>
+        </article>
+
+        <article class="module-card" id="module-3">
+          <small>Module 3</small>
+          <h3>Verbe et temps</h3>
+          <p>Le cœur verbal est exploré à travers les principales particules temporelles, l’expression de la condition et des modalités, ainsi que les constructions impératives.</p>
+          <ul class="module-lessons">
+            <li><a href="module-3.html#lesson-15">Le verbe « être »</a></li>
+            <li><a href="module-3.html#lesson-16">Présent et particule « ka »</a></li>
+            <li><a href="module-3.html#lesson-17">Le passé</a></li>
+            <li><a href="module-3.html#lesson-18">Futur et conditionnel</a></li>
+            <li><a href="module-3.html#lesson-19">La phrase conditionnelle</a></li>
+            <li><a href="module-3.html#lesson-20">L’impératif</a></li>
+            <li><a href="module-3.html#lesson-21">Le passif</a></li>
+            <li><a href="module-3.html#lesson-22">Les verbes composés</a></li>
+            <li><a href="module-3.html#lesson-23">Obligation et probabilité</a></li>
+            <li><a href="module-3.html#lesson-24">Le verbe « pouvoir »</a></li>
+          </ul>
+          <a class="module-card-link" href="module-3.html">Accéder au module 3</a>
+        </article>
+
+        <article class="module-card" id="module-4">
+          <small>Module 4</small>
+          <h3>Structures nominales et quantification</h3>
+          <p>Les derniers chapitres couvrent l’organisation du groupe nominal, l’adjectif, les degrés de comparaison et les outils de quantification.</p>
+          <ul class="module-lessons">
+            <li><a href="module-4.html#lesson-25">Les usages de « sé »</a></li>
+            <li><a href="module-4.html#lesson-26">Le nom commun</a></li>
+            <li><a href="module-4.html#lesson-27">Noms propres, titres et adresses</a></li>
+            <li><a href="module-4.html#lesson-28">L’adjectif</a></li>
+            <li><a href="module-4.html#lesson-29">Le comparatif</a></li>
+            <li><a href="module-4.html#lesson-30">Le superlatif</a></li>
+            <li><a href="module-4.html#lesson-31">Quantification et numération (I)</a></li>
+            <li><a href="module-4.html#lesson-32">Quantification et numération (II)</a></li>
+          </ul>
+          <a class="module-card-link" href="module-4.html">Accéder au module 4</a>
+        </article>
+      </div>
     </section>
   </main>
 
   <footer>
-    <p>Travail collaboratif · Merci à tou·te·s les contributrices et contributeurs !</p>
+    <p class="footer-pill">Mise à jour des règles grammaticales pour accompagner les exercices de créole martiniquais.</p>
+    <a class="link-button" href="subscribe.html">S’abonner à la newsletter</a>
+    <p class="footer-note">Travail collaboratif · Merci à tou·te·s les contributrices et contributeurs !</p>
   </footer>
 
   <script>

--- a/module-1.html
+++ b/module-1.html
@@ -127,7 +127,7 @@
       outline: none;
     }
 
-    .module-link.is-current {
+    .module-link[aria-current="page"] {
       background: rgba(139, 92, 246, 0.32);
       color: white;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
@@ -253,39 +253,6 @@
       outline: none;
     }
 
-    @media (max-width: 720px) {
-      .lesson-nav {
-        justify-content: center;
-        text-align: center;
-      }
-
-      .module-links {
-        justify-content: center;
-      }
-
-      .menu {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-      }
-
-      .menu-panel {
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-      }
-    }
-
-    @media (prefers-color-scheme: dark) {
-      nav {
-        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
-      }
-
-      footer p {
-        background: rgba(30, 17, 52, 0.62);
-      }
-    }
-
     main {
       padding: 3rem 1.5rem 4.5rem;
       max-width: 1100px;
@@ -310,95 +277,68 @@
       margin-bottom: 0.75rem;
     }
 
-    h3 {
-      color: var(--muted);
-      margin-bottom: 0.6rem;
-      font-size: 1.05rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
     p {
       margin: 0.6rem 0;
     }
 
-    ul,
-    ol {
-      margin: 0.75rem 0 0.75rem 1.25rem;
-      padding: 0;
-    }
-
-    li {
-      margin-bottom: 0.45rem;
-    }
-
-    .module-card .module-lessons {
-      list-style: none;
-      margin: 1.1rem 0 1.6rem;
-      padding: 0;
+    .module-card {
       display: grid;
-      gap: 0.5rem;
+      gap: 1.1rem;
     }
 
-    .module-card .module-lessons li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.55);
-      padding: 0.75rem 1rem;
-      border-radius: 16px;
-      font-weight: 600;
-      color: var(--accent-strong);
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
-    }
-
-    .examples {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 0.75rem;
-      margin: 1rem 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .examples li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.85);
-      padding: 0.9rem 1.1rem;
-      border-radius: 14px;
+    .module-card p {
       margin: 0;
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
     }
 
-    .note {
-      background: rgba(250, 204, 21, 0.18);
-      border-left: 4px solid #facc15;
-      padding: 0.85rem 1.1rem;
-      border-radius: 14px;
-      margin: 1.2rem 0;
+    .module-lessons {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .module-lessons a {
+      text-decoration: none;
       color: inherit;
-      box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.12);
-    }
-
-    .module-cta {
+      font-weight: 600;
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      padding: 0.75rem 1.4rem;
-      border-radius: 999px;
-      background: linear-gradient(135deg, rgba(139, 92, 246, 0.9), rgba(56, 189, 248, 0.75));
-      color: white;
+    }
+
+    .module-lessons a::before {
+      content: "→";
+      color: var(--accent-strong);
+      font-weight: 700;
+    }
+
+    .module-card-link {
+      justify-self: start;
       text-decoration: none;
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.85), rgba(56, 189, 248, 0.75));
+      color: white;
       font-weight: 600;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+      padding: 0.85rem 1.4rem;
+      border-radius: 999px;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .module-cta:hover,
-    .module-cta:focus-visible {
+    .module-card-link:hover,
+    .module-card-link:focus-visible {
       transform: translateY(-2px);
       box-shadow: 0 22px 40px rgba(80, 56, 160, 0.36);
       outline: none;
+    }
+
+    .module-card small {
+      color: var(--muted);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
 
     footer {
@@ -420,25 +360,61 @@
       backdrop-filter: blur(16px);
       box-shadow: 0 12px 30px var(--shadow);
     }
+
+    @media (max-width: 720px) {
+      .lesson-nav {
+        justify-content: center;
+      }
+
+      .module-links {
+        justify-content: center;
+      }
+
+      .menu {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+      }
+
+      .menu-panel {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+      }
+
+      .module-card-link {
+        justify-self: center;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      nav {
+        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
+      }
+
+      footer p {
+        background: rgba(30, 17, 52, 0.62);
+      }
+    }
   </style>
 </head>
 <body>
-  <header>
+<header>
     <h1>Grammaire Martiniquaise</h1>
-    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en leçons pour accompagner vos exercices et révisions.</p>
+    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en modules thématiques pour accomp
+agner vos exercices et révisions.</p>
   </header>
-
-  <nav aria-label="Navigation des leçons">
+  <nav aria-label="Navigation principale">
     <div class="lesson-nav">
-      <div class="module-links" role="list">
-        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
-        <a class="module-link is-current" href="module-1.html" role="listitem" aria-current="page">Module 1</a>
-        <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
-        <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
-        <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
+      <div class="module-links">
+        <a class="module-link" href="index.html">Accueil</a>
+        <a class="module-link" href="module-1.html" aria-current="page">Module 1</a>
+        <a class="module-link" href="module-2.html">Module 2</a>
+        <a class="module-link" href="module-3.html">Module 3</a>
+        <a class="module-link" href="module-4.html">Module 4</a>
       </div>
       <details class="menu">
-        <summary class="menu-toggle">
+        <summary class="menu-toggle" aria-expanded="false">
           Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
@@ -446,7 +422,7 @@
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Module 1 · Déterminants et interactions</p>
+            <p class="menu-group-title">Leçons 1 à 9</p>
             <ul>
               <li><a href="#lesson-1">L’article défini</a></li>
               <li><a href="#lesson-2">L’article indéfini</a></li>
@@ -465,145 +441,156 @@
   </nav>
   <main>
     <section id="lesson-1">
-      <h2>L’article défini</h2>
-      <p>L’article défini du créole martiniquais est postposé et varie selon la finale phonétique du nom. Les formes principales sont <strong>-la</strong> après une consonne et <strong>-a</strong> après une voyelle. Après une voyelle nasale, on rencontre les variantes <strong>-lan</strong> et <strong>-an</strong>; d’autres formes comme <strong>-wa</strong>, <strong>-wan</strong>, <strong>-ya</strong> ou <strong>-yan</strong> peuvent apparaître selon la liaison.</p>
-      <ul class="examples">
-        <li><strong>boug-la</strong> : le type · <strong>fanm-lan</strong> : la femme</li>
-        <li><strong>loto-a</strong> : la voiture · <strong>sitwon-an</strong> : le citron</li>
-        <li><strong>dto-wa</strong> : l’eau · <strong>zyé-ya</strong> : l’œil</li>
-        <li><strong>kabrit la ou maré a</strong> : la chèvre que tu as attachée</li>
-      </ul>
-      <p>Dans les relatives, le « que » français est implicite et un article de rappel se place en fin de subordonnée lorsque l’antécédent possède déjà un article défini. Le trait d’union est indispensable pour distinguer les constructions nominales des adjectifs.</p>
-      <div class="note">Le créole martiniquais ne marque pas le genre grammatical : seules les distinctions sémantiques (mâle, femelle, inanimé) sont conservées.</div>
-    </section>
+          <h2>L’article défini</h2>
+          <p>L’article défini du créole martiniquais est postposé et varie selon la finale phonétique du nom. Les formes principales sont <strong>-la</strong> après une consonne et <strong>-a</strong> après une voyelle. Après une voyelle nasale, on rencontre les variantes <strong>-lan</strong> et <strong>-an</strong>; d’autres formes comme <strong>-wa</strong>, <strong>-wan</strong>, <strong>-ya</strong> ou <strong>-yan</strong> peuvent apparaître selon la liaison.</p>
+          <ul class="examples">
+            <li><strong>boug-la</strong> : le type · <strong>fanm-lan</strong> : la femme</li>
+            <li><strong>loto-a</strong> : la voiture · <strong>sitwon-an</strong> : le citron</li>
+            <li><strong>dto-wa</strong> : l’eau · <strong>zyé-ya</strong> : l’œil</li>
+            <li><strong>kabrit la ou maré a</strong> : la chèvre que tu as attachée</li>
+          </ul>
+          <p>Dans les relatives, le « que » français est implicite et un article de rappel se place en fin de subordonnée lorsque l’antécédent possède déjà un article défini. Le trait d’union est indispensable pour distinguer les constructions nominales des adjectifs.</p>
+          <div class="note">Le créole martiniquais ne marque pas le genre grammatical : seules les distinctions sémantiques (mâle, femelle, inanimé) sont conservées.</div>
+        </section>
 
     <section id="lesson-2">
-      <h2>L’article indéfini</h2>
-      <p>L’indéfini possède la forme unique <strong>an</strong> placée avant le nom, sans distinction de genre. Il peut se combiner avec des possessifs ou d’autres déterminants. Au pluriel, l’absence d’article marque l’indéfini (« forme zéro »), mais on peut rencontrer <strong>dé</strong> dans des contextes spécifiques ou exclamations avec <strong>yan</strong>.</p>
-      <ul class="examples">
-        <li><strong>an boug</strong> : un type · <strong>an madanm</strong> : une femme</li>
-        <li><strong>té ni an fwa…</strong> : il était une fois</li>
-        <li><strong>Mi dé boug kouyon !</strong> : Voilà des types idiots !</li>
-        <li><strong>man pa wè pyès zanmi</strong> : je n’ai vu aucun ami</li>
-      </ul>
-      <p>La négation introduit des nuances : <strong>pa</strong> + indéfini pour « ne… pas », <strong>pyès</strong> pour « aucun ». Des formes pronominales dérivées (par ex. <strong>yann</strong>) expriment « un seul ».</p>
-    </section>
+          <h2>L’article indéfini</h2>
+          <p>L’indéfini possède la forme unique <strong>an</strong> placée avant le nom, sans distinction de genre. Il peut se combiner avec des possessifs ou d’autres déterminants. Au pluriel, l’absence d’article marque l’indéfini (« forme zéro »), mais on peut rencontrer <strong>dé</strong> dans des contextes spécifiques ou exclamations avec <strong>yan</strong>.</p>
+          <ul class="examples">
+            <li><strong>an boug</strong> : un type · <strong>an madanm</strong> : une femme</li>
+            <li><strong>té ni an fwa…</strong> : il était une fois</li>
+            <li><strong>Mi dé boug kouyon !</strong> : Voilà des types idiots !</li>
+            <li><strong>man pa wè pyès zanmi</strong> : je n’ai vu aucun ami</li>
+          </ul>
+          <p>La négation introduit des nuances : <strong>pa</strong> + indéfini pour « ne… pas », <strong>pyès</strong> pour « aucun ». Des formes pronominales dérivées (par ex. <strong>yann</strong>) expriment « un seul ».</p>
+        </section>
 
     <section id="lesson-3">
-      <h2>Le pluriel</h2>
-      <p>Le pluriel défini se forme avec <strong>sé …-la</strong> ou <strong>sé …-a</strong> selon la finale du mot, alors que le pluriel indéfini est généralement exprimé par la forme zéro ou par <strong>dé</strong>. L’article permet de distinguer les ensembles particuliers des valeurs générales.</p>
-      <ul class="examples">
-        <li><strong>sé bèf-la</strong> : les bœufs · <strong>sé soulyé-a</strong> : les chaussures</li>
-        <li><strong>man wè kay</strong> : j’ai vu des maisons · <strong>man wè sé kay-la</strong> : j’ai vu les maisons</li>
-        <li><strong>sé mèt-la ka palé</strong> : les maîtres parlent</li>
-        <li><strong>tamwen</strong> : les miens (général) · <strong>sé tamwen-an</strong> : les miens (particulier)</li>
-      </ul>
-      <p>Selon les régions, d’autres marques comme <strong>lé</strong> peuvent remplacer <strong>sé</strong>. Les possessifs se combinent avec l’article pour préciser la portée.</p>
-    </section>
+          <h2>Le pluriel</h2>
+          <p>Le pluriel défini se forme avec <strong>sé …-la</strong> ou <strong>sé …-a</strong> selon la finale du mot, alors que le pluriel indéfini est généralement exprimé par la forme zéro ou par <strong>dé</strong>. L’article permet de distinguer les ensembles particuliers des valeurs générales.</p>
+          <ul class="examples">
+            <li><strong>sé bèf-la</strong> : les bœufs · <strong>sé soulyé-a</strong> : les chaussures</li>
+            <li><strong>man wè kay</strong> : j’ai vu des maisons · <strong>man wè sé kay-la</strong> : j’ai vu les maisons</li>
+            <li><strong>sé mèt-la ka palé</strong> : les maîtres parlent</li>
+            <li><strong>tamwen</strong> : les miens (général) · <strong>sé tamwen-an</strong> : les miens (particulier)</li>
+          </ul>
+          <p>Selon les régions, d’autres marques comme <strong>lé</strong> peuvent remplacer <strong>sé</strong>. Les possessifs se combinent avec l’article pour préciser la portée.</p>
+        </section>
 
     <section id="lesson-4">
-      <h2>Les pronoms personnels</h2>
-      <p>Les pronoms distinguent formes toniques et atones, avec des variantes après voyelle. Les pronoms objets suivent toujours le verbe. Les compléments directs de chose utilisent souvent <strong>sa</strong> plutôt qu’un pronom personnel.</p>
-      <ul class="examples">
-        <li><strong>mwen / man</strong> : je · <strong>wou / ou / ’w</strong> : tu · <strong>li / i / y</strong> : il/elle</li>
-        <li><strong>man wè’w</strong> : je t’ai vu(e) · <strong>kité’y palé</strong> : laisse-le parler</li>
-        <li><strong>man ka ba’y li</strong> : je le lui donne (personne avant objet)</li>
-        <li><strong>nou fè sa</strong> : nous l’avons fait</li>
-      </ul>
-      <p>Les formes réfléchies fusionnent avec <strong>kò-</strong> (ex. <strong>kòmwen</strong>). Les intensifs (<strong>mwen menm la</strong>) servent à insister sur le sujet.</p>
-    </section>
+          <h2>Les pronoms personnels</h2>
+          <p>Les pronoms distinguent formes toniques et atones, avec des variantes après voyelle. Les pronoms objets suivent toujours le verbe. Les compléments directs de chose utilisent souvent <strong>sa</strong> plutôt qu’un pronom personnel.</p>
+          <ul class="examples">
+            <li><strong>mwen / man</strong> : je · <strong>wou / ou / ’w</strong> : tu · <strong>li / i / y</strong> : il/elle</li>
+            <li><strong>man wè’w</strong> : je t’ai vu(e) · <strong>kité’y palé</strong> : laisse-le parler</li>
+            <li><strong>man ka ba’y li</strong> : je le lui donne (personne avant objet)</li>
+            <li><strong>nou fè sa</strong> : nous l’avons fait</li>
+          </ul>
+          <p>Les formes réfléchies fusionnent avec <strong>kò-</strong> (ex. <strong>kòmwen</strong>). Les intensifs (<strong>mwen menm la</strong>) servent à insister sur le sujet.</p>
+        </section>
 
     <section id="lesson-5">
-      <h2>Les possessifs</h2>
-      <p>La possession se marque en plaçant le pronom personnel après le nom. L’article défini détermine la portée (générale ou particulière). Les formes pronominales dérivées utilisent la particule <strong>ta</strong> pour exprimer « le mien », « les nôtres », etc.</p>
-      <ul class="examples">
-        <li><strong>tab li</strong> : ses tables (général) · <strong>tab li a</strong> : sa table</li>
-        <li><strong>loto mwen</strong> : mes voitures · <strong>loto mwen an</strong> : ma voiture</li>
-        <li><strong>tamwen</strong> : les miens · <strong>tamwen an</strong> : le mien</li>
-        <li><strong>kisa ki ta’w ?</strong> : qu’est-ce qui est à toi ?</li>
-      </ul>
-      <p>Lorsque l’on présume l’unicité (parents, conjoint), l’article disparaît : <strong>papa’w</strong>, <strong>manman’w</strong>. Des tournures comme <strong>an yich mwen</strong> signifient « un de mes enfants ».</p>
-    </section>
+          <h2>Les possessifs</h2>
+          <p>La possession se marque en plaçant le pronom personnel après le nom. L’article défini détermine la portée (générale ou particulière). Les formes pronominales dérivées utilisent la particule <strong>ta</strong> pour exprimer « le mien », « les nôtres », etc.</p>
+          <ul class="examples">
+            <li><strong>tab li</strong> : ses tables (général) · <strong>tab li a</strong> : sa table</li>
+            <li><strong>loto mwen</strong> : mes voitures · <strong>loto mwen an</strong> : ma voiture</li>
+            <li><strong>tamwen</strong> : les miens · <strong>tamwen an</strong> : le mien</li>
+            <li><strong>kisa ki ta’w ?</strong> : qu’est-ce qui est à toi ?</li>
+          </ul>
+          <p>Lorsque l’on présume l’unicité (parents, conjoint), l’article disparaît : <strong>papa’w</strong>, <strong>manman’w</strong>. Des tournures comme <strong>an yich mwen</strong> signifient « un de mes enfants ».</p>
+        </section>
 
     <section id="lesson-6">
-      <h2>Les démonstratifs</h2>
-      <p>Le démonstratif adjectival <strong>tala</strong> se place après le nom avec un trait d’union. Des variantes abrégées (<strong>taa</strong>) existent. Le pluriel se forme avec <strong>sé</strong> et des pronoms démonstratifs (<strong>sé tala</strong>) reprennent l’antécédent.</p>
-      <ul class="examples">
-        <li><strong>bagay-tala</strong> : cette chose-ci/là</li>
-        <li><strong>sé moun-tala</strong> : ces gens-là</li>
-        <li><strong>tala ki palé a sé mèt-la</strong> : celui qui a parlé, c’est le maître</li>
-        <li><strong>ba mwen sa</strong> : donne-moi cela</li>
-      </ul>
-      <p>L’article défini peut jouer un rôle démonstratif (<strong>boug-la</strong> = « ce type »). Les expressions temporelles (<strong>oswè-a</strong>, <strong>bonmaten-an</strong>) utilisent l’article pour indiquer la précision.</p>
-    </section>
+          <h2>Les démonstratifs</h2>
+          <p>Le démonstratif adjectival <strong>tala</strong> se place après le nom avec un trait d’union. Des variantes abrégées (<strong>taa</strong>) existent. Le pluriel se forme avec <strong>sé</strong> et des pronoms démonstratifs (<strong>sé tala</strong>) reprennent l’antécédent.</p>
+          <ul class="examples">
+            <li><strong>bagay-tala</strong> : cette chose-ci/là</li>
+            <li><strong>sé moun-tala</strong> : ces gens-là</li>
+            <li><strong>tala ki palé a sé mèt-la</strong> : celui qui a parlé, c’est le maître</li>
+            <li><strong>ba mwen sa</strong> : donne-moi cela</li>
+          </ul>
+          <p>L’article défini peut jouer un rôle démonstratif (<strong>boug-la</strong> = « ce type »). Les expressions temporelles (<strong>oswè-a</strong>, <strong>bonmaten-an</strong>) utilisent l’article pour indiquer la précision.</p>
+        </section>
 
     <section id="lesson-7">
-      <h2>Les relatifs</h2>
-      <p>Le relatif <strong>ki</strong> s’utilise lorsque l’antécédent est sujet, tandis que la forme zéro s’applique aux compléments. Un article de rappel clôt les subordonnées lorsque l’antécédent est déterminé. Le mot explétif <strong>éti</strong> peut précéder le relatif.</p>
-      <ul class="examples">
-        <li><strong>sé Pyè ki vòlé bèf-la</strong> : c’est Pierre qui a volé le bœuf</li>
-        <li><strong>sé bèf-la Pyè vòlé</strong> : c’est le bœuf que Pierre a volé</li>
-        <li><strong>boug-la ki ka rété Fodfrans la</strong> : le type qui habite Fort-de-France</li>
-        <li><strong>koutla-a man ka koupé kann épi’y la</strong> : le coutelas avec lequel je coupe la canne</li>
-      </ul>
-      <p>Les traductions de « dont », « où », « lequel » s’appuient sur des structures possessives ou prépositionnelles (<strong>mi boug-la i té ka palé’w la</strong>).</p>
-    </section>
+          <h2>Les relatifs</h2>
+          <p>Le relatif <strong>ki</strong> s’utilise lorsque l’antécédent est sujet, tandis que la forme zéro s’applique aux compléments. Un article de rappel clôt les subordonnées lorsque l’antécédent est déterminé. Le mot explétif <strong>éti</strong> peut précéder le relatif.</p>
+          <ul class="examples">
+            <li><strong>sé Pyè ki vòlé bèf-la</strong> : c’est Pierre qui a volé le bœuf</li>
+            <li><strong>sé bèf-la Pyè vòlé</strong> : c’est le bœuf que Pierre a volé</li>
+            <li><strong>boug-la ki ka rété Fodfrans la</strong> : le type qui habite Fort-de-France</li>
+            <li><strong>koutla-a man ka koupé kann épi’y la</strong> : le coutelas avec lequel je coupe la canne</li>
+          </ul>
+          <p>Les traductions de « dont », « où », « lequel » s’appuient sur des structures possessives ou prépositionnelles (<strong>mi boug-la i té ka palé’w la</strong>).</p>
+        </section>
 
     <section id="lesson-8">
-      <h2>L’interrogation</h2>
-      <p>L’interrogation se marque par l’intonation ou par des particules (<strong>ès</strong>, <strong>an</strong>, <strong>wi</strong>, <strong>non</strong>, <strong>pa vré</strong>). Les interrogatifs se combinent souvent avec le relatif <strong>ki</strong>.</p>
-      <ul class="examples">
-        <li><strong>ou ka vini, an ?</strong> : tu viens ?</li>
-        <li><strong>ès i fè sa ?</strong> : est-ce qu’il a fait ça ?</li>
-        <li><strong>ki moun ki fè sa ?</strong> : qui a fait ça ?</li>
-        <li><strong>poutji ou pa vini ?</strong> : pourquoi n’es-tu pas venu ?</li>
-      </ul>
-      <p>Les formes interrogatives couvrent qui (<strong>ki moun</strong>), quoi (<strong>kisa</strong>), quel (<strong>kilès</strong>), où (<strong>koté</strong>, <strong>oti</strong>), comment (<strong>ki mannyè</strong>), pourquoi (<strong>poutji</strong>), quand (<strong>ki tan</strong>, <strong>ki jou</strong>).</p>
-    </section>
+          <h2>L’interrogation</h2>
+          <p>L’interrogation se marque par l’intonation ou par des particules (<strong>ès</strong>, <strong>an</strong>, <strong>wi</strong>, <strong>non</strong>, <strong>pa vré</strong>). Les interrogatifs se combinent souvent avec le relatif <strong>ki</strong>.</p>
+          <ul class="examples">
+            <li><strong>ou ka vini, an ?</strong> : tu viens ?</li>
+            <li><strong>ès i fè sa ?</strong> : est-ce qu’il a fait ça ?</li>
+            <li><strong>ki moun ki fè sa ?</strong> : qui a fait ça ?</li>
+            <li><strong>poutji ou pa vini ?</strong> : pourquoi n’es-tu pas venu ?</li>
+          </ul>
+          <p>Les formes interrogatives couvrent qui (<strong>ki moun</strong>), quoi (<strong>kisa</strong>), quel (<strong>kilès</strong>), où (<strong>koté</strong>, <strong>oti</strong>), comment (<strong>ki mannyè</strong>), pourquoi (<strong>poutji</strong>), quand (<strong>ki tan</strong>, <strong>ki jou</strong>).</p>
+        </section>
 
     <section id="lesson-9">
-      <h2>La négation</h2>
-      <p>La particule <strong>pa</strong> précède le verbe pour exprimer la négation. Selon le temps, elle peut varier : <strong>pé</strong> devant <strong>ké</strong> (futur/conditionnel), <strong>poko</strong> pour « pas encore », <strong>pa… ankò</strong> pour « ne… plus ».</p>
-      <ul class="examples">
-        <li><strong>i pa ni lajan</strong> : il n’a pas d’argent</li>
-        <li><strong>nou pé ké kontan</strong> : nous ne serons pas contents</li>
-        <li><strong>i pòkò fè sa</strong> : il ne l’a pas encore fait</li>
-        <li><strong>man pa wè pyès moun</strong> : je n’ai vu personne</li>
-      </ul>
-      <p>Des intensificateurs comme <strong>pyès</strong>, <strong>ayen</strong>, <strong>janmen</strong> renforcent la négation. La place de <strong>pa</strong> autour du verbe <strong>pé</strong> (pouvoir) influe sur le sens (<strong>i pa pé</strong> vs <strong>i pé pa</strong>).</p>
-    </section>
+          <h2>La négation</h2>
+          <p>La particule <strong>pa</strong> précède le verbe pour exprimer la négation. Selon le temps, elle peut varier : <strong>pé</strong> devant <strong>ké</strong> (futur/conditionnel), <strong>poko</strong> pour « pas encore », <strong>pa… ankò</strong> pour « ne… plus ».</p>
+          <ul class="examples">
+            <li><strong>i pa ni lajan</strong> : il n’a pas d’argent</li>
+            <li><strong>nou pé ké kontan</strong> : nous ne serons pas contents</li>
+            <li><strong>i pòkò fè sa</strong> : il ne l’a pas encore fait</li>
+            <li><strong>man pa wè pyès moun</strong> : je n’ai vu personne</li>
+          </ul>
+          <p>Des intensificateurs comme <strong>pyès</strong>, <strong>ayen</strong>, <strong>janmen</strong> renforcent la négation. La place de <strong>pa</strong> autour du verbe <strong>pé</strong> (pouvoir) influe sur le sens (<strong>i pa pé</strong> vs <strong>i pé pa</strong>).</p>
+        </section>
   </main>
-
-  <footer>
-    <p>Mise à jour des règles grammaticales pour accompagner les exercices de créole martiniquais.</p>
+<footer>
+    <p>Travail collaboratif · Merci à tou·te·s les contributrices et contributeurs !</p>
   </footer>
+<script>
+    const menus = document.querySelectorAll('details.menu');
 
-  <script>
-    const menu = document.querySelector('.menu');
+    menus.forEach((menu) => {
+      const summary = menu.querySelector('summary');
+      const links = menu.querySelectorAll('a');
 
-    if (menu) {
-      const panel = menu.querySelector('.menu-panel');
+      if (summary) {
+        summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        menu.addEventListener('toggle', () => {
+          summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        });
+      }
 
-      panel?.addEventListener('click', (event) => {
-        const link = event.target.closest('a');
-        if (link) {
+      links.forEach((link) => {
+        link.addEventListener('click', () => {
           menu.removeAttribute('open');
-        }
+        });
       });
+    });
 
-      document.addEventListener('click', (event) => {
+    document.addEventListener('click', (event) => {
+      menus.forEach((menu) => {
         if (!menu.contains(event.target)) {
           menu.removeAttribute('open');
         }
       });
+    });
 
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-          menu.removeAttribute('open');
-          menu.querySelector('summary')?.focus();
-        }
-      });
-    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        menus.forEach((menu) => {
+          if (menu.open) {
+            menu.removeAttribute('open');
+            menu.querySelector('summary')?.focus();
+          }
+        });
+      }
+    });
   </script>
 </body>
 </html>

--- a/module-1.html
+++ b/module-1.html
@@ -431,97 +431,146 @@
   <nav aria-label="Navigation des leçons">
     <div class="lesson-nav">
       <div class="module-links" role="list">
-        <a class="module-link is-current" href="index.html" role="listitem" aria-current="page">Sommaire</a>
-        <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
+        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
+        <a class="module-link is-current" href="module-1.html" role="listitem" aria-current="page">Module 1</a>
         <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
         <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
         <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
       </div>
       <details class="menu">
         <summary class="menu-toggle">
-          Sommaire des modules
+          Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Explorer les modules</p>
+            <p class="menu-group-title">Module 1 · Déterminants et interactions</p>
             <ul>
-              <li><a href="#module-1">Module 1 · Déterminants et interactions</a></li>
-              <li><a href="#module-2">Module 2 · Prépositions et expressions</a></li>
-              <li><a href="#module-3">Module 3 · Verbe et temps</a></li>
-              <li><a href="#module-4">Module 4 · Structures nominales et quantification</a></li>
+              <li><a href="#lesson-1">L’article défini</a></li>
+              <li><a href="#lesson-2">L’article indéfini</a></li>
+              <li><a href="#lesson-3">Le pluriel</a></li>
+              <li><a href="#lesson-4">Les pronoms personnels</a></li>
+              <li><a href="#lesson-5">Les possessifs</a></li>
+              <li><a href="#lesson-6">Les démonstratifs</a></li>
+              <li><a href="#lesson-7">Les relatifs</a></li>
+              <li><a href="#lesson-8">L’interrogation</a></li>
+              <li><a href="#lesson-9">La négation</a></li>
             </ul>
           </div>
         </div>
       </details>
     </div>
   </nav>
-
   <main>
-    <section class="module-card" id="module-1">
-      <h2>Module 1 · Déterminants et interactions</h2>
-      <p>Approfondissez l’usage des déterminants, pronoms et outils interrogatifs essentiels du créole martiniquais.</p>
-      <ul class="module-lessons">
-        <li>L’article défini</li>
-        <li>L’article indéfini</li>
-        <li>Le pluriel</li>
-        <li>Les pronoms personnels</li>
-        <li>Les possessifs</li>
-        <li>Les démonstratifs</li>
-        <li>Les relatifs</li>
-        <li>L’interrogation</li>
-        <li>La négation</li>
+    <section id="lesson-1">
+      <h2>L’article défini</h2>
+      <p>L’article défini du créole martiniquais est postposé et varie selon la finale phonétique du nom. Les formes principales sont <strong>-la</strong> après une consonne et <strong>-a</strong> après une voyelle. Après une voyelle nasale, on rencontre les variantes <strong>-lan</strong> et <strong>-an</strong>; d’autres formes comme <strong>-wa</strong>, <strong>-wan</strong>, <strong>-ya</strong> ou <strong>-yan</strong> peuvent apparaître selon la liaison.</p>
+      <ul class="examples">
+        <li><strong>boug-la</strong> : le type · <strong>fanm-lan</strong> : la femme</li>
+        <li><strong>loto-a</strong> : la voiture · <strong>sitwon-an</strong> : le citron</li>
+        <li><strong>dto-wa</strong> : l’eau · <strong>zyé-ya</strong> : l’œil</li>
+        <li><strong>kabrit la ou maré a</strong> : la chèvre que tu as attachée</li>
       </ul>
-      <a class="module-cta" href="module-1.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <p>Dans les relatives, le « que » français est implicite et un article de rappel se place en fin de subordonnée lorsque l’antécédent possède déjà un article défini. Le trait d’union est indispensable pour distinguer les constructions nominales des adjectifs.</p>
+      <div class="note">Le créole martiniquais ne marque pas le genre grammatical : seules les distinctions sémantiques (mâle, femelle, inanimé) sont conservées.</div>
     </section>
 
-    <section class="module-card" id="module-2">
-      <h2>Module 2 · Prépositions et expressions</h2>
-      <p>Explorez les principales particules prépositionnelles et exclamatives pour gagner en fluidité dans vos échanges.</p>
-      <ul class="module-lessons">
-        <li>L’exclamation</li>
-        <li>La préposition « à »</li>
-        <li>La préposition « de »</li>
-        <li>Autres prépositions (I)</li>
-        <li>Autres prépositions (II)</li>
+    <section id="lesson-2">
+      <h2>L’article indéfini</h2>
+      <p>L’indéfini possède la forme unique <strong>an</strong> placée avant le nom, sans distinction de genre. Il peut se combiner avec des possessifs ou d’autres déterminants. Au pluriel, l’absence d’article marque l’indéfini (« forme zéro »), mais on peut rencontrer <strong>dé</strong> dans des contextes spécifiques ou exclamations avec <strong>yan</strong>.</p>
+      <ul class="examples">
+        <li><strong>an boug</strong> : un type · <strong>an madanm</strong> : une femme</li>
+        <li><strong>té ni an fwa…</strong> : il était une fois</li>
+        <li><strong>Mi dé boug kouyon !</strong> : Voilà des types idiots !</li>
+        <li><strong>man pa wè pyès zanmi</strong> : je n’ai vu aucun ami</li>
       </ul>
-      <a class="module-cta" href="module-2.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <p>La négation introduit des nuances : <strong>pa</strong> + indéfini pour « ne… pas », <strong>pyès</strong> pour « aucun ». Des formes pronominales dérivées (par ex. <strong>yann</strong>) expriment « un seul ».</p>
     </section>
 
-    <section class="module-card" id="module-3">
-      <h2>Module 3 · Verbe et temps</h2>
-      <p>Maîtrisez les valeurs temporelles et aspectuelles en contexte : être, temps simples, conditionnel ou impératif.</p>
-      <ul class="module-lessons">
-        <li>Le verbe « être »</li>
-        <li>Présent et particule « ka »</li>
-        <li>Le passé</li>
-        <li>Futur et conditionnel</li>
-        <li>La phrase conditionnelle</li>
-        <li>L’impératif</li>
-        <li>Le passif</li>
-        <li>Les verbes composés</li>
-        <li>Obligation et probabilité</li>
-        <li>Le verbe « pouvoir »</li>
+    <section id="lesson-3">
+      <h2>Le pluriel</h2>
+      <p>Le pluriel défini se forme avec <strong>sé …-la</strong> ou <strong>sé …-a</strong> selon la finale du mot, alors que le pluriel indéfini est généralement exprimé par la forme zéro ou par <strong>dé</strong>. L’article permet de distinguer les ensembles particuliers des valeurs générales.</p>
+      <ul class="examples">
+        <li><strong>sé bèf-la</strong> : les bœufs · <strong>sé soulyé-a</strong> : les chaussures</li>
+        <li><strong>man wè kay</strong> : j’ai vu des maisons · <strong>man wè sé kay-la</strong> : j’ai vu les maisons</li>
+        <li><strong>sé mèt-la ka palé</strong> : les maîtres parlent</li>
+        <li><strong>tamwen</strong> : les miens (général) · <strong>sé tamwen-an</strong> : les miens (particulier)</li>
       </ul>
-      <a class="module-cta" href="module-3.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <p>Selon les régions, d’autres marques comme <strong>lé</strong> peuvent remplacer <strong>sé</strong>. Les possessifs se combinent avec l’article pour préciser la portée.</p>
     </section>
 
-    <section class="module-card" id="module-4">
-      <h2>Module 4 · Structures nominales et quantification</h2>
-      <p>Consolidez la construction du nom et la quantification pour nuancer descriptions et comparaisons.</p>
-      <ul class="module-lessons">
-        <li>Les usages de « sé »</li>
-        <li>Le nom commun</li>
-        <li>Noms propres, titres et adresses</li>
-        <li>L’adjectif</li>
-        <li>Le comparatif</li>
-        <li>Le superlatif</li>
-        <li>Quantification et numération (I)</li>
-        <li>Quantification et numération (II)</li>
+    <section id="lesson-4">
+      <h2>Les pronoms personnels</h2>
+      <p>Les pronoms distinguent formes toniques et atones, avec des variantes après voyelle. Les pronoms objets suivent toujours le verbe. Les compléments directs de chose utilisent souvent <strong>sa</strong> plutôt qu’un pronom personnel.</p>
+      <ul class="examples">
+        <li><strong>mwen / man</strong> : je · <strong>wou / ou / ’w</strong> : tu · <strong>li / i / y</strong> : il/elle</li>
+        <li><strong>man wè’w</strong> : je t’ai vu(e) · <strong>kité’y palé</strong> : laisse-le parler</li>
+        <li><strong>man ka ba’y li</strong> : je le lui donne (personne avant objet)</li>
+        <li><strong>nou fè sa</strong> : nous l’avons fait</li>
       </ul>
-      <a class="module-cta" href="module-4.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <p>Les formes réfléchies fusionnent avec <strong>kò-</strong> (ex. <strong>kòmwen</strong>). Les intensifs (<strong>mwen menm la</strong>) servent à insister sur le sujet.</p>
+    </section>
+
+    <section id="lesson-5">
+      <h2>Les possessifs</h2>
+      <p>La possession se marque en plaçant le pronom personnel après le nom. L’article défini détermine la portée (générale ou particulière). Les formes pronominales dérivées utilisent la particule <strong>ta</strong> pour exprimer « le mien », « les nôtres », etc.</p>
+      <ul class="examples">
+        <li><strong>tab li</strong> : ses tables (général) · <strong>tab li a</strong> : sa table</li>
+        <li><strong>loto mwen</strong> : mes voitures · <strong>loto mwen an</strong> : ma voiture</li>
+        <li><strong>tamwen</strong> : les miens · <strong>tamwen an</strong> : le mien</li>
+        <li><strong>kisa ki ta’w ?</strong> : qu’est-ce qui est à toi ?</li>
+      </ul>
+      <p>Lorsque l’on présume l’unicité (parents, conjoint), l’article disparaît : <strong>papa’w</strong>, <strong>manman’w</strong>. Des tournures comme <strong>an yich mwen</strong> signifient « un de mes enfants ».</p>
+    </section>
+
+    <section id="lesson-6">
+      <h2>Les démonstratifs</h2>
+      <p>Le démonstratif adjectival <strong>tala</strong> se place après le nom avec un trait d’union. Des variantes abrégées (<strong>taa</strong>) existent. Le pluriel se forme avec <strong>sé</strong> et des pronoms démonstratifs (<strong>sé tala</strong>) reprennent l’antécédent.</p>
+      <ul class="examples">
+        <li><strong>bagay-tala</strong> : cette chose-ci/là</li>
+        <li><strong>sé moun-tala</strong> : ces gens-là</li>
+        <li><strong>tala ki palé a sé mèt-la</strong> : celui qui a parlé, c’est le maître</li>
+        <li><strong>ba mwen sa</strong> : donne-moi cela</li>
+      </ul>
+      <p>L’article défini peut jouer un rôle démonstratif (<strong>boug-la</strong> = « ce type »). Les expressions temporelles (<strong>oswè-a</strong>, <strong>bonmaten-an</strong>) utilisent l’article pour indiquer la précision.</p>
+    </section>
+
+    <section id="lesson-7">
+      <h2>Les relatifs</h2>
+      <p>Le relatif <strong>ki</strong> s’utilise lorsque l’antécédent est sujet, tandis que la forme zéro s’applique aux compléments. Un article de rappel clôt les subordonnées lorsque l’antécédent est déterminé. Le mot explétif <strong>éti</strong> peut précéder le relatif.</p>
+      <ul class="examples">
+        <li><strong>sé Pyè ki vòlé bèf-la</strong> : c’est Pierre qui a volé le bœuf</li>
+        <li><strong>sé bèf-la Pyè vòlé</strong> : c’est le bœuf que Pierre a volé</li>
+        <li><strong>boug-la ki ka rété Fodfrans la</strong> : le type qui habite Fort-de-France</li>
+        <li><strong>koutla-a man ka koupé kann épi’y la</strong> : le coutelas avec lequel je coupe la canne</li>
+      </ul>
+      <p>Les traductions de « dont », « où », « lequel » s’appuient sur des structures possessives ou prépositionnelles (<strong>mi boug-la i té ka palé’w la</strong>).</p>
+    </section>
+
+    <section id="lesson-8">
+      <h2>L’interrogation</h2>
+      <p>L’interrogation se marque par l’intonation ou par des particules (<strong>ès</strong>, <strong>an</strong>, <strong>wi</strong>, <strong>non</strong>, <strong>pa vré</strong>). Les interrogatifs se combinent souvent avec le relatif <strong>ki</strong>.</p>
+      <ul class="examples">
+        <li><strong>ou ka vini, an ?</strong> : tu viens ?</li>
+        <li><strong>ès i fè sa ?</strong> : est-ce qu’il a fait ça ?</li>
+        <li><strong>ki moun ki fè sa ?</strong> : qui a fait ça ?</li>
+        <li><strong>poutji ou pa vini ?</strong> : pourquoi n’es-tu pas venu ?</li>
+      </ul>
+      <p>Les formes interrogatives couvrent qui (<strong>ki moun</strong>), quoi (<strong>kisa</strong>), quel (<strong>kilès</strong>), où (<strong>koté</strong>, <strong>oti</strong>), comment (<strong>ki mannyè</strong>), pourquoi (<strong>poutji</strong>), quand (<strong>ki tan</strong>, <strong>ki jou</strong>).</p>
+    </section>
+
+    <section id="lesson-9">
+      <h2>La négation</h2>
+      <p>La particule <strong>pa</strong> précède le verbe pour exprimer la négation. Selon le temps, elle peut varier : <strong>pé</strong> devant <strong>ké</strong> (futur/conditionnel), <strong>poko</strong> pour « pas encore », <strong>pa… ankò</strong> pour « ne… plus ».</p>
+      <ul class="examples">
+        <li><strong>i pa ni lajan</strong> : il n’a pas d’argent</li>
+        <li><strong>nou pé ké kontan</strong> : nous ne serons pas contents</li>
+        <li><strong>i pòkò fè sa</strong> : il ne l’a pas encore fait</li>
+        <li><strong>man pa wè pyès moun</strong> : je n’ai vu personne</li>
+      </ul>
+      <p>Des intensificateurs comme <strong>pyès</strong>, <strong>ayen</strong>, <strong>janmen</strong> renforcent la négation. La place de <strong>pa</strong> autour du verbe <strong>pé</strong> (pouvoir) influe sur le sens (<strong>i pa pé</strong> vs <strong>i pé pa</strong>).</p>
     </section>
   </main>
 

--- a/module-2.html
+++ b/module-2.html
@@ -431,97 +431,91 @@
   <nav aria-label="Navigation des leçons">
     <div class="lesson-nav">
       <div class="module-links" role="list">
-        <a class="module-link is-current" href="index.html" role="listitem" aria-current="page">Sommaire</a>
+        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
         <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
-        <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
+        <a class="module-link is-current" href="module-2.html" role="listitem" aria-current="page">Module 2</a>
         <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
         <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
       </div>
       <details class="menu">
         <summary class="menu-toggle">
-          Sommaire des modules
+          Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Explorer les modules</p>
+            <p class="menu-group-title">Module 2 · Prépositions et expressions</p>
             <ul>
-              <li><a href="#module-1">Module 1 · Déterminants et interactions</a></li>
-              <li><a href="#module-2">Module 2 · Prépositions et expressions</a></li>
-              <li><a href="#module-3">Module 3 · Verbe et temps</a></li>
-              <li><a href="#module-4">Module 4 · Structures nominales et quantification</a></li>
+              <li><a href="#lesson-10">L’exclamation</a></li>
+              <li><a href="#lesson-11">La préposition « à »</a></li>
+              <li><a href="#lesson-12">La préposition « de »</a></li>
+              <li><a href="#lesson-13">Autres prépositions (I)</a></li>
+              <li><a href="#lesson-14">Autres prépositions (II)</a></li>
             </ul>
           </div>
         </div>
       </details>
     </div>
   </nav>
-
   <main>
-    <section class="module-card" id="module-1">
-      <h2>Module 1 · Déterminants et interactions</h2>
-      <p>Approfondissez l’usage des déterminants, pronoms et outils interrogatifs essentiels du créole martiniquais.</p>
-      <ul class="module-lessons">
-        <li>L’article défini</li>
-        <li>L’article indéfini</li>
-        <li>Le pluriel</li>
-        <li>Les pronoms personnels</li>
-        <li>Les possessifs</li>
-        <li>Les démonstratifs</li>
-        <li>Les relatifs</li>
-        <li>L’interrogation</li>
-        <li>La négation</li>
+    <section id="lesson-10">
+      <h2>L’exclamation</h2>
+      <p>Plusieurs particules expriment l’exclamation et l’intensité : <strong>fout</strong>, <strong>wi</strong>, <strong>mé</strong>, <strong>wo</strong>, <strong>dann</strong>, <strong>aten</strong>, <strong>papa</strong>, <strong>mézanmi</strong>, <strong>an</strong>, <strong>woy</strong>, <strong>mi</strong>, <strong>joy</strong>, <strong>yan</strong>, <strong>pou</strong>. Elles peuvent être autonomes ou combinées pour renforcer une réaction.</p>
+      <ul class="examples">
+        <li><strong>fout madanm-la bèl !</strong> : que la dame est belle !</li>
+        <li><strong>mé i mové !</strong> : qu’il est méchant !</li>
+        <li><strong>woy woy woy !</strong> : oh là là !</li>
+        <li><strong>mi kalté gwo madanm !</strong> : quelle grosse femme !</li>
       </ul>
-      <a class="module-cta" href="module-1.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <p>Certains termes sont répétés pour intensifier l’émotion (<strong>pa… pa… pa…</strong>, <strong>an an an an</strong>).</p>
     </section>
 
-    <section class="module-card" id="module-2">
-      <h2>Module 2 · Prépositions et expressions</h2>
-      <p>Explorez les principales particules prépositionnelles et exclamatives pour gagner en fluidité dans vos échanges.</p>
-      <ul class="module-lessons">
-        <li>L’exclamation</li>
-        <li>La préposition « à »</li>
-        <li>La préposition « de »</li>
-        <li>Autres prépositions (I)</li>
-        <li>Autres prépositions (II)</li>
+    <section id="lesson-11">
+      <h2>La préposition « à »</h2>
+      <p>La préposition française « à » peut être rendue par une forme zéro ou par diverses particules selon le contexte : <strong>a</strong>, <strong>ta</strong>, <strong>an</strong>, <strong>épi</strong>, <strong>ala</strong>, <strong>ka</strong>, <strong>ba</strong>, <strong>pou</strong>, <strong>o</strong>, <strong>rivé</strong>.</p>
+      <ul class="examples">
+        <li><strong>ba Pyè lajan</strong> : donne de l’argent à Pierre</li>
+        <li><strong>man ka alé lanmès</strong> : je vais à la messe</li>
+        <li><strong>vini a katrè</strong> : viens à quatre heures</li>
+        <li><strong>pòté patjé-tala ba papa’w</strong> : porte ce paquet à ton père</li>
       </ul>
-      <a class="module-cta" href="module-2.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <p>Les constructions diffèrent selon qu’il s’agit d’attribution, de caractérisation, de localisation, de destination ou de verbe particulier.</p>
     </section>
 
-    <section class="module-card" id="module-3">
-      <h2>Module 3 · Verbe et temps</h2>
-      <p>Maîtrisez les valeurs temporelles et aspectuelles en contexte : être, temps simples, conditionnel ou impératif.</p>
-      <ul class="module-lessons">
-        <li>Le verbe « être »</li>
-        <li>Présent et particule « ka »</li>
-        <li>Le passé</li>
-        <li>Futur et conditionnel</li>
-        <li>La phrase conditionnelle</li>
-        <li>L’impératif</li>
-        <li>Le passif</li>
-        <li>Les verbes composés</li>
-        <li>Obligation et probabilité</li>
-        <li>Le verbe « pouvoir »</li>
+    <section id="lesson-12">
+      <h2>La préposition « de »</h2>
+      <p>« De » se traduit par la forme zéro pour l’appartenance, la partitive, la provenance, etc., mais aussi par <strong>di</strong>, <strong>sòti</strong>, <strong>an</strong>, ou <strong>adan</strong> selon la nuance (matière, provenance, localisation, dénombrement).</p>
+      <ul class="examples">
+        <li><strong>joujou timanmay-la</strong> : le jouet de l’enfant</li>
+        <li><strong>i bwè dlo</strong> : il a bu de l’eau</li>
+        <li><strong>man kontan di’w</strong> : je suis content de toi</li>
+        <li><strong>dè adan yo chapé</strong> : deux d’entre eux se sont échappés</li>
       </ul>
-      <a class="module-cta" href="module-3.html">Accéder au module <span aria-hidden="true">→</span></a>
     </section>
 
-    <section class="module-card" id="module-4">
-      <h2>Module 4 · Structures nominales et quantification</h2>
-      <p>Consolidez la construction du nom et la quantification pour nuancer descriptions et comparaisons.</p>
-      <ul class="module-lessons">
-        <li>Les usages de « sé »</li>
-        <li>Le nom commun</li>
-        <li>Noms propres, titres et adresses</li>
-        <li>L’adjectif</li>
-        <li>Le comparatif</li>
-        <li>Le superlatif</li>
-        <li>Quantification et numération (I)</li>
-        <li>Quantification et numération (II)</li>
+    <section id="lesson-13">
+      <h2>Autres prépositions (I)</h2>
+      <p>Les prépositions françaises « pour », « vers », « en/dans », « chez », « contre » se rendent en créole par plusieurs équivalents dépendant du sens précis.</p>
+      <ul class="examples">
+        <li><strong>man ka travay pou érisi</strong> : je travaille pour réussir</li>
+        <li><strong>man ké fè tou sa man pé ba’w</strong> : je ferai tout ce que je peux pour toi</li>
+        <li><strong>nou ka alé o Pòl</strong> : nous allons vers Paul</li>
+        <li><strong>pòté sa alé lakay Pyè</strong> : porte ça chez Pierre</li>
+        <li><strong>nou ké goumen kont yo</strong> : nous nous battrons contre eux</li>
       </ul>
-      <a class="module-cta" href="module-4.html">Accéder au module <span aria-hidden="true">→</span></a>
+    </section>
+
+    <section id="lesson-14">
+      <h2>Autres prépositions (II)</h2>
+      <p><strong>épi</strong> traduit fréquemment « avec », complété par <strong>ansanm épi</strong> pour l’accompagnement. D’autres prépositions usuelles : <strong>apré</strong>, <strong>avan</strong>, <strong>dépi</strong>, <strong>dèyè</strong>, <strong>douvan</strong>, <strong>ant</strong>, <strong>adan</strong>, <strong>an déwò</strong>, <strong>jik</strong>, <strong>magré</strong>, <strong>san</strong>, <strong>silon</strong>, <strong>anba</strong>, <strong>anlè</strong>.</p>
+      <ul class="examples">
+        <li><strong>frè mwen vini épi madanm li</strong> : mon frère est venu avec sa femme</li>
+        <li><strong>dèyè kay-la</strong> : derrière la maison</li>
+        <li><strong>ann Italie</strong> : en Italie</li>
+        <li><strong>anba tab-la</strong> : sous la table</li>
+      </ul>
     </section>
   </main>
 

--- a/module-2.html
+++ b/module-2.html
@@ -127,7 +127,7 @@
       outline: none;
     }
 
-    .module-link.is-current {
+    .module-link[aria-current="page"] {
       background: rgba(139, 92, 246, 0.32);
       color: white;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
@@ -253,39 +253,6 @@
       outline: none;
     }
 
-    @media (max-width: 720px) {
-      .lesson-nav {
-        justify-content: center;
-        text-align: center;
-      }
-
-      .module-links {
-        justify-content: center;
-      }
-
-      .menu {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-      }
-
-      .menu-panel {
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-      }
-    }
-
-    @media (prefers-color-scheme: dark) {
-      nav {
-        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
-      }
-
-      footer p {
-        background: rgba(30, 17, 52, 0.62);
-      }
-    }
-
     main {
       padding: 3rem 1.5rem 4.5rem;
       max-width: 1100px;
@@ -310,95 +277,68 @@
       margin-bottom: 0.75rem;
     }
 
-    h3 {
-      color: var(--muted);
-      margin-bottom: 0.6rem;
-      font-size: 1.05rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
     p {
       margin: 0.6rem 0;
     }
 
-    ul,
-    ol {
-      margin: 0.75rem 0 0.75rem 1.25rem;
-      padding: 0;
-    }
-
-    li {
-      margin-bottom: 0.45rem;
-    }
-
-    .module-card .module-lessons {
-      list-style: none;
-      margin: 1.1rem 0 1.6rem;
-      padding: 0;
+    .module-card {
       display: grid;
-      gap: 0.5rem;
+      gap: 1.1rem;
     }
 
-    .module-card .module-lessons li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.55);
-      padding: 0.75rem 1rem;
-      border-radius: 16px;
-      font-weight: 600;
-      color: var(--accent-strong);
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
-    }
-
-    .examples {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 0.75rem;
-      margin: 1rem 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .examples li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.85);
-      padding: 0.9rem 1.1rem;
-      border-radius: 14px;
+    .module-card p {
       margin: 0;
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
     }
 
-    .note {
-      background: rgba(250, 204, 21, 0.18);
-      border-left: 4px solid #facc15;
-      padding: 0.85rem 1.1rem;
-      border-radius: 14px;
-      margin: 1.2rem 0;
+    .module-lessons {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .module-lessons a {
+      text-decoration: none;
       color: inherit;
-      box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.12);
-    }
-
-    .module-cta {
+      font-weight: 600;
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      padding: 0.75rem 1.4rem;
-      border-radius: 999px;
-      background: linear-gradient(135deg, rgba(139, 92, 246, 0.9), rgba(56, 189, 248, 0.75));
-      color: white;
+    }
+
+    .module-lessons a::before {
+      content: "→";
+      color: var(--accent-strong);
+      font-weight: 700;
+    }
+
+    .module-card-link {
+      justify-self: start;
       text-decoration: none;
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.85), rgba(56, 189, 248, 0.75));
+      color: white;
       font-weight: 600;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+      padding: 0.85rem 1.4rem;
+      border-radius: 999px;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .module-cta:hover,
-    .module-cta:focus-visible {
+    .module-card-link:hover,
+    .module-card-link:focus-visible {
       transform: translateY(-2px);
       box-shadow: 0 22px 40px rgba(80, 56, 160, 0.36);
       outline: none;
+    }
+
+    .module-card small {
+      color: var(--muted);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
 
     footer {
@@ -420,25 +360,61 @@
       backdrop-filter: blur(16px);
       box-shadow: 0 12px 30px var(--shadow);
     }
+
+    @media (max-width: 720px) {
+      .lesson-nav {
+        justify-content: center;
+      }
+
+      .module-links {
+        justify-content: center;
+      }
+
+      .menu {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+      }
+
+      .menu-panel {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+      }
+
+      .module-card-link {
+        justify-self: center;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      nav {
+        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
+      }
+
+      footer p {
+        background: rgba(30, 17, 52, 0.62);
+      }
+    }
   </style>
 </head>
 <body>
-  <header>
+<header>
     <h1>Grammaire Martiniquaise</h1>
-    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en leçons pour accompagner vos exercices et révisions.</p>
+    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en modules thématiques pour accomp
+agner vos exercices et révisions.</p>
   </header>
-
-  <nav aria-label="Navigation des leçons">
+  <nav aria-label="Navigation principale">
     <div class="lesson-nav">
-      <div class="module-links" role="list">
-        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
-        <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
-        <a class="module-link is-current" href="module-2.html" role="listitem" aria-current="page">Module 2</a>
-        <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
-        <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
+      <div class="module-links">
+        <a class="module-link" href="index.html">Accueil</a>
+        <a class="module-link" href="module-1.html">Module 1</a>
+        <a class="module-link" href="module-2.html" aria-current="page">Module 2</a>
+        <a class="module-link" href="module-3.html">Module 3</a>
+        <a class="module-link" href="module-4.html">Module 4</a>
       </div>
       <details class="menu">
-        <summary class="menu-toggle">
+        <summary class="menu-toggle" aria-expanded="false">
           Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
@@ -446,7 +422,7 @@
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Module 2 · Prépositions et expressions</p>
+            <p class="menu-group-title">Leçons 10 à 14</p>
             <ul>
               <li><a href="#lesson-10">L’exclamation</a></li>
               <li><a href="#lesson-11">La préposition « à »</a></li>
@@ -461,94 +437,105 @@
   </nav>
   <main>
     <section id="lesson-10">
-      <h2>L’exclamation</h2>
-      <p>Plusieurs particules expriment l’exclamation et l’intensité : <strong>fout</strong>, <strong>wi</strong>, <strong>mé</strong>, <strong>wo</strong>, <strong>dann</strong>, <strong>aten</strong>, <strong>papa</strong>, <strong>mézanmi</strong>, <strong>an</strong>, <strong>woy</strong>, <strong>mi</strong>, <strong>joy</strong>, <strong>yan</strong>, <strong>pou</strong>. Elles peuvent être autonomes ou combinées pour renforcer une réaction.</p>
-      <ul class="examples">
-        <li><strong>fout madanm-la bèl !</strong> : que la dame est belle !</li>
-        <li><strong>mé i mové !</strong> : qu’il est méchant !</li>
-        <li><strong>woy woy woy !</strong> : oh là là !</li>
-        <li><strong>mi kalté gwo madanm !</strong> : quelle grosse femme !</li>
-      </ul>
-      <p>Certains termes sont répétés pour intensifier l’émotion (<strong>pa… pa… pa…</strong>, <strong>an an an an</strong>).</p>
-    </section>
+          <h2>L’exclamation</h2>
+          <p>Plusieurs particules expriment l’exclamation et l’intensité : <strong>fout</strong>, <strong>wi</strong>, <strong>mé</strong>, <strong>wo</strong>, <strong>dann</strong>, <strong>aten</strong>, <strong>papa</strong>, <strong>mézanmi</strong>, <strong>an</strong>, <strong>woy</strong>, <strong>mi</strong>, <strong>joy</strong>, <strong>yan</strong>, <strong>pou</strong>. Elles peuvent être autonomes ou combinées pour renforcer une réaction.</p>
+          <ul class="examples">
+            <li><strong>fout madanm-la bèl !</strong> : que la dame est belle !</li>
+            <li><strong>mé i mové !</strong> : qu’il est méchant !</li>
+            <li><strong>woy woy woy !</strong> : oh là là !</li>
+            <li><strong>mi kalté gwo madanm !</strong> : quelle grosse femme !</li>
+          </ul>
+          <p>Certains termes sont répétés pour intensifier l’émotion (<strong>pa… pa… pa…</strong>, <strong>an an an an</strong>).</p>
+        </section>
 
     <section id="lesson-11">
-      <h2>La préposition « à »</h2>
-      <p>La préposition française « à » peut être rendue par une forme zéro ou par diverses particules selon le contexte : <strong>a</strong>, <strong>ta</strong>, <strong>an</strong>, <strong>épi</strong>, <strong>ala</strong>, <strong>ka</strong>, <strong>ba</strong>, <strong>pou</strong>, <strong>o</strong>, <strong>rivé</strong>.</p>
-      <ul class="examples">
-        <li><strong>ba Pyè lajan</strong> : donne de l’argent à Pierre</li>
-        <li><strong>man ka alé lanmès</strong> : je vais à la messe</li>
-        <li><strong>vini a katrè</strong> : viens à quatre heures</li>
-        <li><strong>pòté patjé-tala ba papa’w</strong> : porte ce paquet à ton père</li>
-      </ul>
-      <p>Les constructions diffèrent selon qu’il s’agit d’attribution, de caractérisation, de localisation, de destination ou de verbe particulier.</p>
-    </section>
+          <h2>La préposition « à »</h2>
+          <p>La préposition française « à » peut être rendue par une forme zéro ou par diverses particules selon le contexte : <strong>a</strong>, <strong>ta</strong>, <strong>an</strong>, <strong>épi</strong>, <strong>ala</strong>, <strong>ka</strong>, <strong>ba</strong>, <strong>pou</strong>, <strong>o</strong>, <strong>rivé</strong>.</p>
+          <ul class="examples">
+            <li><strong>ba Pyè lajan</strong> : donne de l’argent à Pierre</li>
+            <li><strong>man ka alé lanmès</strong> : je vais à la messe</li>
+            <li><strong>vini a katrè</strong> : viens à quatre heures</li>
+            <li><strong>pòté patjé-tala ba papa’w</strong> : porte ce paquet à ton père</li>
+          </ul>
+          <p>Les constructions diffèrent selon qu’il s’agit d’attribution, de caractérisation, de localisation, de destination ou de verbe particulier.</p>
+        </section>
 
     <section id="lesson-12">
-      <h2>La préposition « de »</h2>
-      <p>« De » se traduit par la forme zéro pour l’appartenance, la partitive, la provenance, etc., mais aussi par <strong>di</strong>, <strong>sòti</strong>, <strong>an</strong>, ou <strong>adan</strong> selon la nuance (matière, provenance, localisation, dénombrement).</p>
-      <ul class="examples">
-        <li><strong>joujou timanmay-la</strong> : le jouet de l’enfant</li>
-        <li><strong>i bwè dlo</strong> : il a bu de l’eau</li>
-        <li><strong>man kontan di’w</strong> : je suis content de toi</li>
-        <li><strong>dè adan yo chapé</strong> : deux d’entre eux se sont échappés</li>
-      </ul>
-    </section>
+          <h2>La préposition « de »</h2>
+          <p>« De » se traduit par la forme zéro pour l’appartenance, la partitive, la provenance, etc., mais aussi par <strong>di</strong>, <strong>sòti</strong>, <strong>an</strong>, ou <strong>adan</strong> selon la nuance (matière, provenance, localisation, dénombrement).</p>
+          <ul class="examples">
+            <li><strong>joujou timanmay-la</strong> : le jouet de l’enfant</li>
+            <li><strong>i bwè dlo</strong> : il a bu de l’eau</li>
+            <li><strong>man kontan di’w</strong> : je suis content de toi</li>
+            <li><strong>dè adan yo chapé</strong> : deux d’entre eux se sont échappés</li>
+          </ul>
+        </section>
 
     <section id="lesson-13">
-      <h2>Autres prépositions (I)</h2>
-      <p>Les prépositions françaises « pour », « vers », « en/dans », « chez », « contre » se rendent en créole par plusieurs équivalents dépendant du sens précis.</p>
-      <ul class="examples">
-        <li><strong>man ka travay pou érisi</strong> : je travaille pour réussir</li>
-        <li><strong>man ké fè tou sa man pé ba’w</strong> : je ferai tout ce que je peux pour toi</li>
-        <li><strong>nou ka alé o Pòl</strong> : nous allons vers Paul</li>
-        <li><strong>pòté sa alé lakay Pyè</strong> : porte ça chez Pierre</li>
-        <li><strong>nou ké goumen kont yo</strong> : nous nous battrons contre eux</li>
-      </ul>
-    </section>
+          <h2>Autres prépositions (I)</h2>
+          <p>Les prépositions françaises « pour », « vers », « en/dans », « chez », « contre » se rendent en créole par plusieurs équivalents dépendant du sens précis.</p>
+          <ul class="examples">
+            <li><strong>man ka travay pou érisi</strong> : je travaille pour réussir</li>
+            <li><strong>man ké fè tou sa man pé ba’w</strong> : je ferai tout ce que je peux pour toi</li>
+            <li><strong>nou ka alé o Pòl</strong> : nous allons vers Paul</li>
+            <li><strong>pòté sa alé lakay Pyè</strong> : porte ça chez Pierre</li>
+            <li><strong>nou ké goumen kont yo</strong> : nous nous battrons contre eux</li>
+          </ul>
+        </section>
 
     <section id="lesson-14">
-      <h2>Autres prépositions (II)</h2>
-      <p><strong>épi</strong> traduit fréquemment « avec », complété par <strong>ansanm épi</strong> pour l’accompagnement. D’autres prépositions usuelles : <strong>apré</strong>, <strong>avan</strong>, <strong>dépi</strong>, <strong>dèyè</strong>, <strong>douvan</strong>, <strong>ant</strong>, <strong>adan</strong>, <strong>an déwò</strong>, <strong>jik</strong>, <strong>magré</strong>, <strong>san</strong>, <strong>silon</strong>, <strong>anba</strong>, <strong>anlè</strong>.</p>
-      <ul class="examples">
-        <li><strong>frè mwen vini épi madanm li</strong> : mon frère est venu avec sa femme</li>
-        <li><strong>dèyè kay-la</strong> : derrière la maison</li>
-        <li><strong>ann Italie</strong> : en Italie</li>
-        <li><strong>anba tab-la</strong> : sous la table</li>
-      </ul>
-    </section>
+          <h2>Autres prépositions (II)</h2>
+          <p><strong>épi</strong> traduit fréquemment « avec », complété par <strong>ansanm épi</strong> pour l’accompagnement. D’autres prépositions usuelles : <strong>apré</strong>, <strong>avan</strong>, <strong>dépi</strong>, <strong>dèyè</strong>, <strong>douvan</strong>, <strong>ant</strong>, <strong>adan</strong>, <strong>an déwò</strong>, <strong>jik</strong>, <strong>magré</strong>, <strong>san</strong>, <strong>silon</strong>, <strong>anba</strong>, <strong>anlè</strong>.</p>
+          <ul class="examples">
+            <li><strong>frè mwen vini épi madanm li</strong> : mon frère est venu avec sa femme</li>
+            <li><strong>dèyè kay-la</strong> : derrière la maison</li>
+            <li><strong>ann Italie</strong> : en Italie</li>
+            <li><strong>anba tab-la</strong> : sous la table</li>
+          </ul>
+        </section>
   </main>
-
-  <footer>
-    <p>Mise à jour des règles grammaticales pour accompagner les exercices de créole martiniquais.</p>
+<footer>
+    <p>Travail collaboratif · Merci à tou·te·s les contributrices et contributeurs !</p>
   </footer>
+<script>
+    const menus = document.querySelectorAll('details.menu');
 
-  <script>
-    const menu = document.querySelector('.menu');
+    menus.forEach((menu) => {
+      const summary = menu.querySelector('summary');
+      const links = menu.querySelectorAll('a');
 
-    if (menu) {
-      const panel = menu.querySelector('.menu-panel');
+      if (summary) {
+        summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        menu.addEventListener('toggle', () => {
+          summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        });
+      }
 
-      panel?.addEventListener('click', (event) => {
-        const link = event.target.closest('a');
-        if (link) {
+      links.forEach((link) => {
+        link.addEventListener('click', () => {
           menu.removeAttribute('open');
-        }
+        });
       });
+    });
 
-      document.addEventListener('click', (event) => {
+    document.addEventListener('click', (event) => {
+      menus.forEach((menu) => {
         if (!menu.contains(event.target)) {
           menu.removeAttribute('open');
         }
       });
+    });
 
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-          menu.removeAttribute('open');
-          menu.querySelector('summary')?.focus();
-        }
-      });
-    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        menus.forEach((menu) => {
+          if (menu.open) {
+            menu.removeAttribute('open');
+            menu.querySelector('summary')?.focus();
+          }
+        });
+      }
+    });
   </script>
 </body>
 </html>

--- a/module-3.html
+++ b/module-3.html
@@ -431,97 +431,149 @@
   <nav aria-label="Navigation des leçons">
     <div class="lesson-nav">
       <div class="module-links" role="list">
-        <a class="module-link is-current" href="index.html" role="listitem" aria-current="page">Sommaire</a>
+        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
         <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
         <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
-        <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
+        <a class="module-link is-current" href="module-3.html" role="listitem" aria-current="page">Module 3</a>
         <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
       </div>
       <details class="menu">
         <summary class="menu-toggle">
-          Sommaire des modules
+          Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Explorer les modules</p>
+            <p class="menu-group-title">Module 3 · Verbe et temps</p>
             <ul>
-              <li><a href="#module-1">Module 1 · Déterminants et interactions</a></li>
-              <li><a href="#module-2">Module 2 · Prépositions et expressions</a></li>
-              <li><a href="#module-3">Module 3 · Verbe et temps</a></li>
-              <li><a href="#module-4">Module 4 · Structures nominales et quantification</a></li>
+              <li><a href="#lesson-15">Le verbe « être »</a></li>
+              <li><a href="#lesson-16">Présent et particule « ka »</a></li>
+              <li><a href="#lesson-17">Le passé</a></li>
+              <li><a href="#lesson-18">Futur et conditionnel</a></li>
+              <li><a href="#lesson-19">La phrase conditionnelle</a></li>
+              <li><a href="#lesson-20">L’impératif</a></li>
+              <li><a href="#lesson-21">Le passif</a></li>
+              <li><a href="#lesson-22">Les verbes composés</a></li>
+              <li><a href="#lesson-23">Obligation et probabilité</a></li>
+              <li><a href="#lesson-24">Le verbe « pouvoir »</a></li>
             </ul>
           </div>
         </div>
       </details>
     </div>
   </nav>
-
   <main>
-    <section class="module-card" id="module-1">
-      <h2>Module 1 · Déterminants et interactions</h2>
-      <p>Approfondissez l’usage des déterminants, pronoms et outils interrogatifs essentiels du créole martiniquais.</p>
-      <ul class="module-lessons">
-        <li>L’article défini</li>
-        <li>L’article indéfini</li>
-        <li>Le pluriel</li>
-        <li>Les pronoms personnels</li>
-        <li>Les possessifs</li>
-        <li>Les démonstratifs</li>
-        <li>Les relatifs</li>
-        <li>L’interrogation</li>
-        <li>La négation</li>
+    <section id="lesson-15">
+      <h2>Le verbe « être »</h2>
+      <p>Quatre stratégies rendent « être » : forme zéro devant adjectif ou compléments, copule <strong>sé</strong> devant un nom, forme <strong>yé</strong> pour les constructions disloquées ou interrogatives, et verbe plein <strong>èt</strong> dans certains contextes.</p>
+      <ul class="examples">
+        <li><strong>Pyè kontan</strong> : Pierre est content</li>
+        <li><strong>Féfé sé an tigason</strong> : Féfé est un petit garçon</li>
+        <li><strong>koté i yé ?</strong> : où est-il ?</li>
+        <li><strong>i lé èt an bon doktè</strong> : il veut être un bon médecin</li>
       </ul>
-      <a class="module-cta" href="module-1.html">Accéder au module <span aria-hidden="true">→</span></a>
     </section>
 
-    <section class="module-card" id="module-2">
-      <h2>Module 2 · Prépositions et expressions</h2>
-      <p>Explorez les principales particules prépositionnelles et exclamatives pour gagner en fluidité dans vos échanges.</p>
-      <ul class="module-lessons">
-        <li>L’exclamation</li>
-        <li>La préposition « à »</li>
-        <li>La préposition « de »</li>
-        <li>Autres prépositions (I)</li>
-        <li>Autres prépositions (II)</li>
+    <section id="lesson-16">
+      <h2>Présent et particule « ka »</h2>
+      <p>La particule <strong>ka</strong> exprime l’aspect duratif ou habituel. Elle peut disparaître avec certains verbes statifs (<strong>enmen</strong>, <strong>konnèt</strong>, <strong>ni</strong>, <strong>sav</strong>, etc.) sauf pour indiquer l’habitude.</p>
+      <ul class="examples">
+        <li><strong>man ka chanté</strong> : je chante / je suis en train de chanter</li>
+        <li><strong>Pyè ka pran kouri</strong> : Pierre se met à courir</li>
+        <li><strong>i pa ka travay ankò</strong> : il ne travaille plus</li>
+        <li><strong>man sav sa</strong> : je sais ça (sans <strong>ka</strong>)</li>
       </ul>
-      <a class="module-cta" href="module-2.html">Accéder au module <span aria-hidden="true">→</span></a>
     </section>
 
-    <section class="module-card" id="module-3">
-      <h2>Module 3 · Verbe et temps</h2>
-      <p>Maîtrisez les valeurs temporelles et aspectuelles en contexte : être, temps simples, conditionnel ou impératif.</p>
-      <ul class="module-lessons">
-        <li>Le verbe « être »</li>
-        <li>Présent et particule « ka »</li>
-        <li>Le passé</li>
-        <li>Futur et conditionnel</li>
-        <li>La phrase conditionnelle</li>
-        <li>L’impératif</li>
-        <li>Le passif</li>
-        <li>Les verbes composés</li>
-        <li>Obligation et probabilité</li>
-        <li>Le verbe « pouvoir »</li>
+    <section id="lesson-17">
+      <h2>Le passé</h2>
+      <p>Le passé s’exprime par la forme simple (équivalent passé composé/passé simple) ou par la particule <strong>té</strong> (antériorité ou imparfait selon le verbe). La combinaison <strong>té ka</strong> correspond à l’imparfait duratif.</p>
+      <ul class="examples">
+        <li><strong>yo pati</strong> : ils sont partis</li>
+        <li><strong>man té di’w</strong> : je t’avais dit</li>
+        <li><strong>man té lé</strong> : je voulais / j’ai voulu</li>
+        <li><strong>i té ka travay</strong> : il travaillait</li>
       </ul>
-      <a class="module-cta" href="module-3.html">Accéder au module <span aria-hidden="true">→</span></a>
     </section>
 
-    <section class="module-card" id="module-4">
-      <h2>Module 4 · Structures nominales et quantification</h2>
-      <p>Consolidez la construction du nom et la quantification pour nuancer descriptions et comparaisons.</p>
-      <ul class="module-lessons">
-        <li>Les usages de « sé »</li>
-        <li>Le nom commun</li>
-        <li>Noms propres, titres et adresses</li>
-        <li>L’adjectif</li>
-        <li>Le comparatif</li>
-        <li>Le superlatif</li>
-        <li>Quantification et numération (I)</li>
-        <li>Quantification et numération (II)</li>
+    <section id="lesson-18">
+      <h2>Futur et conditionnel</h2>
+      <p>La particule <strong>ké</strong> marque le futur (avec variante proche <strong>kay</strong>). La combinaison <strong>té ké</strong> forme le conditionnel, tandis que <strong>sé</strong> peut rendre un conditionnel optatif. L’antériorité se gère avec <strong>fini</strong>.</p>
+      <ul class="examples">
+        <li><strong>nou ké dòmi bonnè</strong> : nous dormirons tôt</li>
+        <li><strong>ou kay travay</strong> : tu vas travailler (futur proche)</li>
+        <li><strong>yo té ké ja pati</strong> : ils seraient déjà partis</li>
+        <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
       </ul>
-      <a class="module-cta" href="module-4.html">Accéder au module <span aria-hidden="true">→</span></a>
+    </section>
+
+    <section id="lesson-19">
+      <h2>La phrase conditionnelle</h2>
+      <p>Les subordonnées conditionnelles utilisent <strong>si</strong> ou <strong>siyanka</strong> et se combinent avec différents temps (<strong>ka</strong>, forme simple, <strong>té ka</strong>, <strong>té ké</strong>, optatif). Le choix reflète la probabilité ou l’irréel.</p>
+      <ul class="examples">
+        <li><strong>si ou lévé, ou ké tann</strong> : si tu te lèves, tu entendras</li>
+        <li><strong>si ou té travay, ou té ké ni</strong> : si tu avais travaillé, tu aurais eu</li>
+        <li><strong>siyanka man touvé, man ké pòté</strong> : si je trouve, je porterai</li>
+        <li><strong>siyanka ou té ké ni, ou té ké ba</strong> : si tu avais, tu donnerais</li>
+      </ul>
+    </section>
+
+    <section id="lesson-20">
+      <h2>L’impératif</h2>
+      <p>L’impératif utilise la forme verbale simple, éventuellement doublée ou renforcée par des particules (<strong>anni</strong>, <strong>kon</strong>, <strong>tou sa</strong>). Certaines personnes emploient <strong>annou</strong> pour la 1<sup>re</sup> pluriel. Des expressions avec <strong>kité</strong>, <strong>ba</strong> ou <strong>prété</strong> rendent l’impératif aux autres personnes.</p>
+      <ul class="examples">
+        <li><strong>sòti la !</strong> : sors de là !</li>
+        <li><strong>pa menyen mwen !</strong> : ne me touche pas !</li>
+        <li><strong>annou chanté !</strong> : chantons !</li>
+        <li><strong>kit’an fè sa !</strong> : laisse-moi faire ça !</li>
+      </ul>
+      <p>Certains verbes comme <strong>lé</strong> ou <strong>pé</strong> n’ont pas d’impératif propre et recourent à des périphrases.</p>
+    </section>
+
+    <section id="lesson-21">
+      <h2>Le passif</h2>
+      <p>Le passif s’exprime sans changement morphologique majeur : on supprime l’agent ou on utilise des participes lexicalisés (<strong>pri</strong>, <strong>fèt</strong>, <strong>bay</strong>). Certaines constructions participiales complètent la description.</p>
+      <ul class="examples">
+        <li><strong>lèt-la voyé</strong> : la lettre est envoyée</li>
+        <li><strong>an kay byen fèt</strong> : une maison bien faite</li>
+        <li><strong>an lajan bay</strong> : une somme donnée</li> 
+        <li><strong>man ka wè’y ka monté mòn-la</strong> : je le vois montant la colline</li>
+      </ul>
+    </section>
+
+    <section id="lesson-22">
+      <h2>Les verbes composés</h2>
+      <p>Le créole combine fréquemment deux verbes pour préciser la nuance aspectuelle ou directionnelle. Un verbe porte le sens lexical, l’autre ajoute une orientation ou une manière.</p>
+      <ul class="examples">
+        <li><strong>maché alé</strong> : marcher vers l’extérieur · <strong>maché vini</strong> : marcher vers l’intérieur</li>
+        <li><strong>mennen alé</strong> : emmener · <strong>pòté vini</strong> : apporter</li>
+        <li><strong>tounen viré</strong> : virevolter · <strong>bay désann</strong> : descendre rapidement</li>
+        <li><strong>gadé wè</strong> : s’occuper de · <strong>chèché gadé wè</strong> : chercher à savoir insistance</li>
+      </ul>
+    </section>
+
+    <section id="lesson-23">
+      <h2>Obligation et probabilité</h2>
+      <p>Trois marqueurs principaux expriment l’obligation : <strong>fok/fo</strong>, <strong>pou</strong> et <strong>dwèt</strong>. Ce dernier véhicule aussi la notion de probabilité selon le contexte.</p>
+      <ul class="examples">
+        <li><strong>fòk ou travay</strong> : il faut que tu travailles</li>
+        <li><strong>sé pati pou nou pati</strong> : il nous faut partir</li>
+        <li><strong>Pyè dwèt travay</strong> : Pierre doit travailler / Pierre travaille sûrement</li>
+        <li><strong>ou té dwèt pati</strong> : tu aurais dû partir</li>
+      </ul>
+    </section>
+
+    <section id="lesson-24">
+      <h2>Le verbe « pouvoir »</h2>
+      <p><strong>pé</strong> traduit la capacité et la possibilité, souvent combiné à <strong>sa</strong> pour indiquer la réussite. La négation se fond avec <strong>pé</strong> au futur (<strong>pé ké</strong>). Le verbe peut aussi exprimer la probabilité.</p>
+      <ul class="examples">
+        <li><strong>ou pé pati</strong> : tu peux partir</li>
+        <li><strong>man ba’y san fran pou i pé sa manjé</strong> : je lui ai donné cent francs pour qu’il puisse manger</li>
+        <li><strong>man pé ké pé vini</strong> : je ne pourrai pas venir</li>
+        <li><strong>i pé ja rivé</strong> : il est peut-être déjà arrivé</li>
+      </ul>
     </section>
   </main>
 

--- a/module-3.html
+++ b/module-3.html
@@ -127,7 +127,7 @@
       outline: none;
     }
 
-    .module-link.is-current {
+    .module-link[aria-current="page"] {
       background: rgba(139, 92, 246, 0.32);
       color: white;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
@@ -253,39 +253,6 @@
       outline: none;
     }
 
-    @media (max-width: 720px) {
-      .lesson-nav {
-        justify-content: center;
-        text-align: center;
-      }
-
-      .module-links {
-        justify-content: center;
-      }
-
-      .menu {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-      }
-
-      .menu-panel {
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-      }
-    }
-
-    @media (prefers-color-scheme: dark) {
-      nav {
-        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
-      }
-
-      footer p {
-        background: rgba(30, 17, 52, 0.62);
-      }
-    }
-
     main {
       padding: 3rem 1.5rem 4.5rem;
       max-width: 1100px;
@@ -310,95 +277,68 @@
       margin-bottom: 0.75rem;
     }
 
-    h3 {
-      color: var(--muted);
-      margin-bottom: 0.6rem;
-      font-size: 1.05rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
     p {
       margin: 0.6rem 0;
     }
 
-    ul,
-    ol {
-      margin: 0.75rem 0 0.75rem 1.25rem;
-      padding: 0;
-    }
-
-    li {
-      margin-bottom: 0.45rem;
-    }
-
-    .module-card .module-lessons {
-      list-style: none;
-      margin: 1.1rem 0 1.6rem;
-      padding: 0;
+    .module-card {
       display: grid;
-      gap: 0.5rem;
+      gap: 1.1rem;
     }
 
-    .module-card .module-lessons li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.55);
-      padding: 0.75rem 1rem;
-      border-radius: 16px;
-      font-weight: 600;
-      color: var(--accent-strong);
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
-    }
-
-    .examples {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 0.75rem;
-      margin: 1rem 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .examples li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.85);
-      padding: 0.9rem 1.1rem;
-      border-radius: 14px;
+    .module-card p {
       margin: 0;
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
     }
 
-    .note {
-      background: rgba(250, 204, 21, 0.18);
-      border-left: 4px solid #facc15;
-      padding: 0.85rem 1.1rem;
-      border-radius: 14px;
-      margin: 1.2rem 0;
+    .module-lessons {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .module-lessons a {
+      text-decoration: none;
       color: inherit;
-      box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.12);
-    }
-
-    .module-cta {
+      font-weight: 600;
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      padding: 0.75rem 1.4rem;
-      border-radius: 999px;
-      background: linear-gradient(135deg, rgba(139, 92, 246, 0.9), rgba(56, 189, 248, 0.75));
-      color: white;
+    }
+
+    .module-lessons a::before {
+      content: "→";
+      color: var(--accent-strong);
+      font-weight: 700;
+    }
+
+    .module-card-link {
+      justify-self: start;
       text-decoration: none;
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.85), rgba(56, 189, 248, 0.75));
+      color: white;
       font-weight: 600;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+      padding: 0.85rem 1.4rem;
+      border-radius: 999px;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .module-cta:hover,
-    .module-cta:focus-visible {
+    .module-card-link:hover,
+    .module-card-link:focus-visible {
       transform: translateY(-2px);
       box-shadow: 0 22px 40px rgba(80, 56, 160, 0.36);
       outline: none;
+    }
+
+    .module-card small {
+      color: var(--muted);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
 
     footer {
@@ -420,25 +360,61 @@
       backdrop-filter: blur(16px);
       box-shadow: 0 12px 30px var(--shadow);
     }
+
+    @media (max-width: 720px) {
+      .lesson-nav {
+        justify-content: center;
+      }
+
+      .module-links {
+        justify-content: center;
+      }
+
+      .menu {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+      }
+
+      .menu-panel {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+      }
+
+      .module-card-link {
+        justify-self: center;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      nav {
+        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
+      }
+
+      footer p {
+        background: rgba(30, 17, 52, 0.62);
+      }
+    }
   </style>
 </head>
 <body>
-  <header>
+<header>
     <h1>Grammaire Martiniquaise</h1>
-    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en leçons pour accompagner vos exercices et révisions.</p>
+    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en modules thématiques pour accomp
+agner vos exercices et révisions.</p>
   </header>
-
-  <nav aria-label="Navigation des leçons">
+  <nav aria-label="Navigation principale">
     <div class="lesson-nav">
-      <div class="module-links" role="list">
-        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
-        <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
-        <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
-        <a class="module-link is-current" href="module-3.html" role="listitem" aria-current="page">Module 3</a>
-        <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
+      <div class="module-links">
+        <a class="module-link" href="index.html">Accueil</a>
+        <a class="module-link" href="module-1.html">Module 1</a>
+        <a class="module-link" href="module-2.html">Module 2</a>
+        <a class="module-link" href="module-3.html" aria-current="page">Module 3</a>
+        <a class="module-link" href="module-4.html">Module 4</a>
       </div>
       <details class="menu">
-        <summary class="menu-toggle">
+        <summary class="menu-toggle" aria-expanded="false">
           Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
@@ -446,7 +422,7 @@
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Module 3 · Verbe et temps</p>
+            <p class="menu-group-title">Leçons 15 à 24</p>
             <ul>
               <li><a href="#lesson-15">Le verbe « être »</a></li>
               <li><a href="#lesson-16">Présent et particule « ka »</a></li>
@@ -466,147 +442,158 @@
   </nav>
   <main>
     <section id="lesson-15">
-      <h2>Le verbe « être »</h2>
-      <p>Quatre stratégies rendent « être » : forme zéro devant adjectif ou compléments, copule <strong>sé</strong> devant un nom, forme <strong>yé</strong> pour les constructions disloquées ou interrogatives, et verbe plein <strong>èt</strong> dans certains contextes.</p>
-      <ul class="examples">
-        <li><strong>Pyè kontan</strong> : Pierre est content</li>
-        <li><strong>Féfé sé an tigason</strong> : Féfé est un petit garçon</li>
-        <li><strong>koté i yé ?</strong> : où est-il ?</li>
-        <li><strong>i lé èt an bon doktè</strong> : il veut être un bon médecin</li>
-      </ul>
-    </section>
+          <h2>Le verbe « être »</h2>
+          <p>Quatre stratégies rendent « être » : forme zéro devant adjectif ou compléments, copule <strong>sé</strong> devant un nom, forme <strong>yé</strong> pour les constructions disloquées ou interrogatives, et verbe plein <strong>èt</strong> dans certains contextes.</p>
+          <ul class="examples">
+            <li><strong>Pyè kontan</strong> : Pierre est content</li>
+            <li><strong>Féfé sé an tigason</strong> : Féfé est un petit garçon</li>
+            <li><strong>koté i yé ?</strong> : où est-il ?</li>
+            <li><strong>i lé èt an bon doktè</strong> : il veut être un bon médecin</li>
+          </ul>
+        </section>
 
     <section id="lesson-16">
-      <h2>Présent et particule « ka »</h2>
-      <p>La particule <strong>ka</strong> exprime l’aspect duratif ou habituel. Elle peut disparaître avec certains verbes statifs (<strong>enmen</strong>, <strong>konnèt</strong>, <strong>ni</strong>, <strong>sav</strong>, etc.) sauf pour indiquer l’habitude.</p>
-      <ul class="examples">
-        <li><strong>man ka chanté</strong> : je chante / je suis en train de chanter</li>
-        <li><strong>Pyè ka pran kouri</strong> : Pierre se met à courir</li>
-        <li><strong>i pa ka travay ankò</strong> : il ne travaille plus</li>
-        <li><strong>man sav sa</strong> : je sais ça (sans <strong>ka</strong>)</li>
-      </ul>
-    </section>
+          <h2>Présent et particule « ka »</h2>
+          <p>La particule <strong>ka</strong> exprime l’aspect duratif ou habituel. Elle peut disparaître avec certains verbes statifs (<strong>enmen</strong>, <strong>konnèt</strong>, <strong>ni</strong>, <strong>sav</strong>, etc.) sauf pour indiquer l’habitude.</p>
+          <ul class="examples">
+            <li><strong>man ka chanté</strong> : je chante / je suis en train de chanter</li>
+            <li><strong>Pyè ka pran kouri</strong> : Pierre se met à courir</li>
+            <li><strong>i pa ka travay ankò</strong> : il ne travaille plus</li>
+            <li><strong>man sav sa</strong> : je sais ça (sans <strong>ka</strong>)</li>
+          </ul>
+        </section>
 
     <section id="lesson-17">
-      <h2>Le passé</h2>
-      <p>Le passé s’exprime par la forme simple (équivalent passé composé/passé simple) ou par la particule <strong>té</strong> (antériorité ou imparfait selon le verbe). La combinaison <strong>té ka</strong> correspond à l’imparfait duratif.</p>
-      <ul class="examples">
-        <li><strong>yo pati</strong> : ils sont partis</li>
-        <li><strong>man té di’w</strong> : je t’avais dit</li>
-        <li><strong>man té lé</strong> : je voulais / j’ai voulu</li>
-        <li><strong>i té ka travay</strong> : il travaillait</li>
-      </ul>
-    </section>
+          <h2>Le passé</h2>
+          <p>Le passé s’exprime par la forme simple (équivalent passé composé/passé simple) ou par la particule <strong>té</strong> (antériorité ou imparfait selon le verbe). La combinaison <strong>té ka</strong> correspond à l’imparfait duratif.</p>
+          <ul class="examples">
+            <li><strong>yo pati</strong> : ils sont partis</li>
+            <li><strong>man té di’w</strong> : je t’avais dit</li>
+            <li><strong>man té lé</strong> : je voulais / j’ai voulu</li>
+            <li><strong>i té ka travay</strong> : il travaillait</li>
+          </ul>
+        </section>
 
     <section id="lesson-18">
-      <h2>Futur et conditionnel</h2>
-      <p>La particule <strong>ké</strong> marque le futur (avec variante proche <strong>kay</strong>). La combinaison <strong>té ké</strong> forme le conditionnel, tandis que <strong>sé</strong> peut rendre un conditionnel optatif. L’antériorité se gère avec <strong>fini</strong>.</p>
-      <ul class="examples">
-        <li><strong>nou ké dòmi bonnè</strong> : nous dormirons tôt</li>
-        <li><strong>ou kay travay</strong> : tu vas travailler (futur proche)</li>
-        <li><strong>yo té ké ja pati</strong> : ils seraient déjà partis</li>
-        <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
-      </ul>
-    </section>
+          <h2>Futur et conditionnel</h2>
+          <p>La particule <strong>ké</strong> marque le futur (avec variante proche <strong>kay</strong>). La combinaison <strong>té ké</strong> forme le conditionnel, tandis que <strong>sé</strong> peut rendre un conditionnel optatif. L’antériorité se gère avec <strong>fini</strong>.</p>
+          <ul class="examples">
+            <li><strong>nou ké dòmi bonnè</strong> : nous dormirons tôt</li>
+            <li><strong>ou kay travay</strong> : tu vas travailler (futur proche)</li>
+            <li><strong>yo té ké ja pati</strong> : ils seraient déjà partis</li>
+            <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
+          </ul>
+        </section>
 
     <section id="lesson-19">
-      <h2>La phrase conditionnelle</h2>
-      <p>Les subordonnées conditionnelles utilisent <strong>si</strong> ou <strong>siyanka</strong> et se combinent avec différents temps (<strong>ka</strong>, forme simple, <strong>té ka</strong>, <strong>té ké</strong>, optatif). Le choix reflète la probabilité ou l’irréel.</p>
-      <ul class="examples">
-        <li><strong>si ou lévé, ou ké tann</strong> : si tu te lèves, tu entendras</li>
-        <li><strong>si ou té travay, ou té ké ni</strong> : si tu avais travaillé, tu aurais eu</li>
-        <li><strong>siyanka man touvé, man ké pòté</strong> : si je trouve, je porterai</li>
-        <li><strong>siyanka ou té ké ni, ou té ké ba</strong> : si tu avais, tu donnerais</li>
-      </ul>
-    </section>
+          <h2>La phrase conditionnelle</h2>
+          <p>Les subordonnées conditionnelles utilisent <strong>si</strong> ou <strong>siyanka</strong> et se combinent avec différents temps (<strong>ka</strong>, forme simple, <strong>té ka</strong>, <strong>té ké</strong>, optatif). Le choix reflète la probabilité ou l’irréel.</p>
+          <ul class="examples">
+            <li><strong>si ou lévé, ou ké tann</strong> : si tu te lèves, tu entendras</li>
+            <li><strong>si ou té travay, ou té ké ni</strong> : si tu avais travaillé, tu aurais eu</li>
+            <li><strong>siyanka man touvé, man ké pòté</strong> : si je trouve, je porterai</li>
+            <li><strong>siyanka ou té ké ni, ou té ké ba</strong> : si tu avais, tu donnerais</li>
+          </ul>
+        </section>
 
     <section id="lesson-20">
-      <h2>L’impératif</h2>
-      <p>L’impératif utilise la forme verbale simple, éventuellement doublée ou renforcée par des particules (<strong>anni</strong>, <strong>kon</strong>, <strong>tou sa</strong>). Certaines personnes emploient <strong>annou</strong> pour la 1<sup>re</sup> pluriel. Des expressions avec <strong>kité</strong>, <strong>ba</strong> ou <strong>prété</strong> rendent l’impératif aux autres personnes.</p>
-      <ul class="examples">
-        <li><strong>sòti la !</strong> : sors de là !</li>
-        <li><strong>pa menyen mwen !</strong> : ne me touche pas !</li>
-        <li><strong>annou chanté !</strong> : chantons !</li>
-        <li><strong>kit’an fè sa !</strong> : laisse-moi faire ça !</li>
-      </ul>
-      <p>Certains verbes comme <strong>lé</strong> ou <strong>pé</strong> n’ont pas d’impératif propre et recourent à des périphrases.</p>
-    </section>
+          <h2>L’impératif</h2>
+          <p>L’impératif utilise la forme verbale simple, éventuellement doublée ou renforcée par des particules (<strong>anni</strong>, <strong>kon</strong>, <strong>tou sa</strong>). Certaines personnes emploient <strong>annou</strong> pour la 1<sup>re</sup> pluriel. Des expressions avec <strong>kité</strong>, <strong>ba</strong> ou <strong>prété</strong> rendent l’impératif aux autres personnes.</p>
+          <ul class="examples">
+            <li><strong>sòti la !</strong> : sors de là !</li>
+            <li><strong>pa menyen mwen !</strong> : ne me touche pas !</li>
+            <li><strong>annou chanté !</strong> : chantons !</li>
+            <li><strong>kit’an fè sa !</strong> : laisse-moi faire ça !</li>
+          </ul>
+          <p>Certains verbes comme <strong>lé</strong> ou <strong>pé</strong> n’ont pas d’impératif propre et recourent à des périphrases.</p>
+        </section>
 
     <section id="lesson-21">
-      <h2>Le passif</h2>
-      <p>Le passif s’exprime sans changement morphologique majeur : on supprime l’agent ou on utilise des participes lexicalisés (<strong>pri</strong>, <strong>fèt</strong>, <strong>bay</strong>). Certaines constructions participiales complètent la description.</p>
-      <ul class="examples">
-        <li><strong>lèt-la voyé</strong> : la lettre est envoyée</li>
-        <li><strong>an kay byen fèt</strong> : une maison bien faite</li>
-        <li><strong>an lajan bay</strong> : une somme donnée</li> 
-        <li><strong>man ka wè’y ka monté mòn-la</strong> : je le vois montant la colline</li>
-      </ul>
-    </section>
+          <h2>Le passif</h2>
+          <p>Le passif s’exprime sans changement morphologique majeur : on supprime l’agent ou on utilise des participes lexicalisés (<strong>pri</strong>, <strong>fèt</strong>, <strong>bay</strong>). Certaines constructions participiales complètent la description.</p>
+          <ul class="examples">
+            <li><strong>lèt-la voyé</strong> : la lettre est envoyée</li>
+            <li><strong>an kay byen fèt</strong> : une maison bien faite</li>
+            <li><strong>an lajan bay</strong> : une somme donnée</li> 
+            <li><strong>man ka wè’y ka monté mòn-la</strong> : je le vois montant la colline</li>
+          </ul>
+        </section>
 
     <section id="lesson-22">
-      <h2>Les verbes composés</h2>
-      <p>Le créole combine fréquemment deux verbes pour préciser la nuance aspectuelle ou directionnelle. Un verbe porte le sens lexical, l’autre ajoute une orientation ou une manière.</p>
-      <ul class="examples">
-        <li><strong>maché alé</strong> : marcher vers l’extérieur · <strong>maché vini</strong> : marcher vers l’intérieur</li>
-        <li><strong>mennen alé</strong> : emmener · <strong>pòté vini</strong> : apporter</li>
-        <li><strong>tounen viré</strong> : virevolter · <strong>bay désann</strong> : descendre rapidement</li>
-        <li><strong>gadé wè</strong> : s’occuper de · <strong>chèché gadé wè</strong> : chercher à savoir insistance</li>
-      </ul>
-    </section>
+          <h2>Les verbes composés</h2>
+          <p>Le créole combine fréquemment deux verbes pour préciser la nuance aspectuelle ou directionnelle. Un verbe porte le sens lexical, l’autre ajoute une orientation ou une manière.</p>
+          <ul class="examples">
+            <li><strong>maché alé</strong> : marcher vers l’extérieur · <strong>maché vini</strong> : marcher vers l’intérieur</li>
+            <li><strong>mennen alé</strong> : emmener · <strong>pòté vini</strong> : apporter</li>
+            <li><strong>tounen viré</strong> : virevolter · <strong>bay désann</strong> : descendre rapidement</li>
+            <li><strong>gadé wè</strong> : s’occuper de · <strong>chèché gadé wè</strong> : chercher à savoir insistance</li>
+          </ul>
+        </section>
 
     <section id="lesson-23">
-      <h2>Obligation et probabilité</h2>
-      <p>Trois marqueurs principaux expriment l’obligation : <strong>fok/fo</strong>, <strong>pou</strong> et <strong>dwèt</strong>. Ce dernier véhicule aussi la notion de probabilité selon le contexte.</p>
-      <ul class="examples">
-        <li><strong>fòk ou travay</strong> : il faut que tu travailles</li>
-        <li><strong>sé pati pou nou pati</strong> : il nous faut partir</li>
-        <li><strong>Pyè dwèt travay</strong> : Pierre doit travailler / Pierre travaille sûrement</li>
-        <li><strong>ou té dwèt pati</strong> : tu aurais dû partir</li>
-      </ul>
-    </section>
+          <h2>Obligation et probabilité</h2>
+          <p>Trois marqueurs principaux expriment l’obligation : <strong>fok/fo</strong>, <strong>pou</strong> et <strong>dwèt</strong>. Ce dernier véhicule aussi la notion de probabilité selon le contexte.</p>
+          <ul class="examples">
+            <li><strong>fòk ou travay</strong> : il faut que tu travailles</li>
+            <li><strong>sé pati pou nou pati</strong> : il nous faut partir</li>
+            <li><strong>Pyè dwèt travay</strong> : Pierre doit travailler / Pierre travaille sûrement</li>
+            <li><strong>ou té dwèt pati</strong> : tu aurais dû partir</li>
+          </ul>
+        </section>
 
     <section id="lesson-24">
-      <h2>Le verbe « pouvoir »</h2>
-      <p><strong>pé</strong> traduit la capacité et la possibilité, souvent combiné à <strong>sa</strong> pour indiquer la réussite. La négation se fond avec <strong>pé</strong> au futur (<strong>pé ké</strong>). Le verbe peut aussi exprimer la probabilité.</p>
-      <ul class="examples">
-        <li><strong>ou pé pati</strong> : tu peux partir</li>
-        <li><strong>man ba’y san fran pou i pé sa manjé</strong> : je lui ai donné cent francs pour qu’il puisse manger</li>
-        <li><strong>man pé ké pé vini</strong> : je ne pourrai pas venir</li>
-        <li><strong>i pé ja rivé</strong> : il est peut-être déjà arrivé</li>
-      </ul>
-    </section>
+          <h2>Le verbe « pouvoir »</h2>
+          <p><strong>pé</strong> traduit la capacité et la possibilité, souvent combiné à <strong>sa</strong> pour indiquer la réussite. La négation se fond avec <strong>pé</strong> au futur (<strong>pé ké</strong>). Le verbe peut aussi exprimer la probabilité.</p>
+          <ul class="examples">
+            <li><strong>ou pé pati</strong> : tu peux partir</li>
+            <li><strong>man ba’y san fran pou i pé sa manjé</strong> : je lui ai donné cent francs pour qu’il puisse manger</li>
+            <li><strong>man pé ké pé vini</strong> : je ne pourrai pas venir</li>
+            <li><strong>i pé ja rivé</strong> : il est peut-être déjà arrivé</li>
+          </ul>
+        </section>
   </main>
-
-  <footer>
-    <p>Mise à jour des règles grammaticales pour accompagner les exercices de créole martiniquais.</p>
+<footer>
+    <p>Travail collaboratif · Merci à tou·te·s les contributrices et contributeurs !</p>
   </footer>
+<script>
+    const menus = document.querySelectorAll('details.menu');
 
-  <script>
-    const menu = document.querySelector('.menu');
+    menus.forEach((menu) => {
+      const summary = menu.querySelector('summary');
+      const links = menu.querySelectorAll('a');
 
-    if (menu) {
-      const panel = menu.querySelector('.menu-panel');
+      if (summary) {
+        summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        menu.addEventListener('toggle', () => {
+          summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        });
+      }
 
-      panel?.addEventListener('click', (event) => {
-        const link = event.target.closest('a');
-        if (link) {
+      links.forEach((link) => {
+        link.addEventListener('click', () => {
           menu.removeAttribute('open');
-        }
+        });
       });
+    });
 
-      document.addEventListener('click', (event) => {
+    document.addEventListener('click', (event) => {
+      menus.forEach((menu) => {
         if (!menu.contains(event.target)) {
           menu.removeAttribute('open');
         }
       });
+    });
 
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-          menu.removeAttribute('open');
-          menu.querySelector('summary')?.focus();
-        }
-      });
-    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        menus.forEach((menu) => {
+          if (menu.open) {
+            menu.removeAttribute('open');
+            menu.querySelector('summary')?.focus();
+          }
+        });
+      }
+    });
   </script>
 </body>
 </html>

--- a/module-4.html
+++ b/module-4.html
@@ -431,97 +431,126 @@
   <nav aria-label="Navigation des leçons">
     <div class="lesson-nav">
       <div class="module-links" role="list">
-        <a class="module-link is-current" href="index.html" role="listitem" aria-current="page">Sommaire</a>
+        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
         <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
         <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
         <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
-        <a class="module-link" href="module-4.html" role="listitem">Module 4</a>
+        <a class="module-link is-current" href="module-4.html" role="listitem" aria-current="page">Module 4</a>
       </div>
       <details class="menu">
         <summary class="menu-toggle">
-          Sommaire des modules
+          Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Explorer les modules</p>
+            <p class="menu-group-title">Module 4 · Structures nominales et quantification</p>
             <ul>
-              <li><a href="#module-1">Module 1 · Déterminants et interactions</a></li>
-              <li><a href="#module-2">Module 2 · Prépositions et expressions</a></li>
-              <li><a href="#module-3">Module 3 · Verbe et temps</a></li>
-              <li><a href="#module-4">Module 4 · Structures nominales et quantification</a></li>
+              <li><a href="#lesson-25">Les usages de « sé »</a></li>
+              <li><a href="#lesson-26">Le nom commun</a></li>
+              <li><a href="#lesson-27">Noms propres, titres et adresses</a></li>
+              <li><a href="#lesson-28">L’adjectif</a></li>
+              <li><a href="#lesson-29">Le comparatif</a></li>
+              <li><a href="#lesson-30">Le superlatif</a></li>
+              <li><a href="#lesson-31">Quantification et numération (I)</a></li>
+              <li><a href="#lesson-32">Quantification et numération (II)</a></li>
             </ul>
           </div>
         </div>
       </details>
     </div>
   </nav>
-
   <main>
-    <section class="module-card" id="module-1">
-      <h2>Module 1 · Déterminants et interactions</h2>
-      <p>Approfondissez l’usage des déterminants, pronoms et outils interrogatifs essentiels du créole martiniquais.</p>
-      <ul class="module-lessons">
-        <li>L’article défini</li>
-        <li>L’article indéfini</li>
-        <li>Le pluriel</li>
-        <li>Les pronoms personnels</li>
-        <li>Les possessifs</li>
-        <li>Les démonstratifs</li>
-        <li>Les relatifs</li>
-        <li>L’interrogation</li>
-        <li>La négation</li>
+    <section id="lesson-25">
+      <h2>Les usages de « sé »</h2>
+      <p><strong>sé</strong> possède quatre fonctions : présentatif (« c’est »), marque du pluriel défini, copule équivalente à « être » et optatif (conditionnel). Plusieurs occurrences peuvent cohabiter dans une même phrase.</p>
+      <ul class="examples">
+        <li><strong>sa, sé ki bagay ?</strong> : ça, qu’est-ce que c’est ?</li>
+        <li><strong>sé zanmi’w la</strong> : tes amis</li>
+        <li><strong>ou sé an salop</strong> : tu es un salaud</li>
+        <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
       </ul>
-      <a class="module-cta" href="module-1.html">Accéder au module <span aria-hidden="true">→</span></a>
     </section>
 
-    <section class="module-card" id="module-2">
-      <h2>Module 2 · Prépositions et expressions</h2>
-      <p>Explorez les principales particules prépositionnelles et exclamatives pour gagner en fluidité dans vos échanges.</p>
-      <ul class="module-lessons">
-        <li>L’exclamation</li>
-        <li>La préposition « à »</li>
-        <li>La préposition « de »</li>
-        <li>Autres prépositions (I)</li>
-        <li>Autres prépositions (II)</li>
+    <section id="lesson-26">
+      <h2>Le nom commun</h2>
+      <p>Les noms peuvent apparaître sans article lorsqu’ils ont une valeur générique. Certains adjectifs ou verbes se nominalisent, souvent avec les préfixes <strong>la-</strong> ou <strong>le-</strong> pour les notions abstraites.</p>
+      <ul class="examples">
+        <li><strong>loto pa pou vini la</strong> : les voitures ne doivent pas venir ici</li>
+        <li><strong>lajistis sé an bon bagay</strong> : la justice est une bonne chose</li>
+        <li><strong>dòmi dous</strong> : c’est bon de dormir</li>
+        <li><strong>i fè an kay pa gran</strong> : il a construit une maison pas grande</li>
       </ul>
-      <a class="module-cta" href="module-2.html">Accéder au module <span aria-hidden="true">→</span></a>
     </section>
 
-    <section class="module-card" id="module-3">
-      <h2>Module 3 · Verbe et temps</h2>
-      <p>Maîtrisez les valeurs temporelles et aspectuelles en contexte : être, temps simples, conditionnel ou impératif.</p>
-      <ul class="module-lessons">
-        <li>Le verbe « être »</li>
-        <li>Présent et particule « ka »</li>
-        <li>Le passé</li>
-        <li>Futur et conditionnel</li>
-        <li>La phrase conditionnelle</li>
-        <li>L’impératif</li>
-        <li>Le passif</li>
-        <li>Les verbes composés</li>
-        <li>Obligation et probabilité</li>
-        <li>Le verbe « pouvoir »</li>
+    <section id="lesson-27">
+      <h2>Noms propres, titres et adresses</h2>
+      <p>Les noms propres peuvent recevoir l’article pour marquer la distance. Les titres et formules d’adresse varient selon le registre : <strong>misyé</strong>, <strong>manzè</strong>, <strong>mésyédanm</strong>, <strong>monchè</strong>, etc. Les noms de pays utilisent des prépositions spécifiques.</p>
+      <ul class="examples">
+        <li><strong>Misiyé Pòl la</strong> : ce Monsieur Paul</li>
+        <li><strong>mésyédanm</strong> : Mesdames et messieurs</li>
+        <li><strong>man dirèktris la konprann...</strong> : cette directrice pense…</li>
+        <li><strong>yo ka soti an Frans</strong> : ils viennent de France</li>
       </ul>
-      <a class="module-cta" href="module-3.html">Accéder au module <span aria-hidden="true">→</span></a>
     </section>
 
-    <section class="module-card" id="module-4">
-      <h2>Module 4 · Structures nominales et quantification</h2>
-      <p>Consolidez la construction du nom et la quantification pour nuancer descriptions et comparaisons.</p>
-      <ul class="module-lessons">
-        <li>Les usages de « sé »</li>
-        <li>Le nom commun</li>
-        <li>Noms propres, titres et adresses</li>
-        <li>L’adjectif</li>
-        <li>Le comparatif</li>
-        <li>Le superlatif</li>
-        <li>Quantification et numération (I)</li>
-        <li>Quantification et numération (II)</li>
+    <section id="lesson-28">
+      <h2>L’adjectif</h2>
+      <p>De nombreux adjectifs résultent de relatives réduites ou de syntagmes nominalisés. Certains intensifs (<strong>bidim</strong>, <strong>manman</strong>) ou diminutifs (<strong>ti monyonyon</strong>) précèdent le nom. Le genre grammatical n’est pas marqué, mais des suffixes (<strong>-èz</strong>) peuvent souligner le féminin sémantique.</p>
+      <ul class="examples">
+        <li><strong>an boug vayan</strong> : un homme courageux</li>
+        <li><strong>an ti monyonyon pen</strong> : un tout petit bout de pain</li>
+        <li><strong>fanm ganmé a</strong> : la femme élégante</li>
+        <li><strong>Pyè, sé an boug blip</strong> : Pierre est un type mal dégrossi</li>
       </ul>
-      <a class="module-cta" href="module-4.html">Accéder au module <span aria-hidden="true">→</span></a>
+      <div class="note">Attention aux ambiguïtés : <strong>fanm kouyon an</strong> = la femme idiote ; <strong>fanm kouyon-an</strong> = la femme de l’idiot.</div>
+    </section>
+
+    <section id="lesson-29">
+      <h2>Le comparatif</h2>
+      <p>La supériorité se marque avec <strong>pli… ki/pasé</strong>, l’égalité avec <strong>osi… ki</strong> ou <strong>otan… otan</strong>, l’infériorité avec <strong>mwen(s)… ki</strong>. Des adverbes (<strong>titak</strong>, <strong>anpil</strong>, <strong>lontan</strong>) modulant l’intensité.</p>
+      <ul class="examples">
+        <li><strong>Pyè pli sòt ki Wobè</strong> : Pierre est plus bête que Robert</li>
+        <li><strong>Féfé osi gwo ki Pyè</strong> : Féfé est aussi gros que Pierre</li>
+        <li><strong>mwen gran ki Pyè</strong> : moins grand que Pierre</li>
+        <li><strong>pli ou ké dòmi, pli ou ké anvi dòmi</strong> : plus tu dormiras, plus tu auras envie de dormir</li>
+      </ul>
+    </section>
+
+    <section id="lesson-30">
+      <h2>Le superlatif</h2>
+      <p>Le superlatif relatif s’appuie sur <strong>pli</strong> ou <strong>mwen</strong> associés à l’article (<strong>sé… a</strong> pour le particulier, <strong>lé</strong> pour le général). Le superlatif absolu se forme par redoublement, particules intensives ou adjectifs comme <strong>bon</strong>, <strong>bèl</strong>, <strong>gwo</strong>, <strong>tou</strong>.</p>
+      <ul class="examples">
+        <li><strong>boug mwen pyétè a</strong> : le type le moins avare</li>
+        <li><strong>Pyè, sé boug pli séryé man konnèt</strong> : Pierre est le type le plus sérieux que je connaisse</li>
+        <li><strong>nou wè an bèl bèl fanm</strong> : nous avons vu une très belle femme</li>
+        <li><strong>i tou kagou</strong> : il est très malade</li>
+      </ul>
+    </section>
+
+    <section id="lesson-31">
+      <h2>Quantification et numération (I)</h2>
+      <p>Les adverbes/adjectifs de quantité incluent <strong>tout</strong>, <strong>chak</strong>, <strong>tjèk</strong>, <strong>yonndé</strong>, <strong>anpil</strong>, <strong>anlo</strong>, <strong>lòt</strong>, <strong>menm</strong>, <strong>kalté</strong>. Ils modulent la portée du nom selon qu’il est défini ou indéfini.</p>
+      <ul class="examples">
+        <li><strong>tout moun</strong> : tout le monde</li>
+        <li><strong>chak moun palé</strong> : chacun a parlé</li>
+        <li><strong>ni tjèk sé moun-la</strong> : il y a quelques-unes de ces personnes</li>
+        <li><strong>man pa enmen kalté moun-tala</strong> : je n’aime pas ce genre de personne</li>
+      </ul>
+    </section>
+
+    <section id="lesson-32">
+      <h2>Quantification et numération (II)</h2>
+      <p>Les numéraux cardinaux (yonn, dé, twa…) et ordinaux (prèmyé, dézyèm…) suivent des règles spécifiques. Certains servent d’intensif. Les expressions de durée ou de fréquence s’appuient sur ces formes.</p>
+      <ul class="examples">
+        <li><strong>ni dé lanné nou la</strong> : cela fait deux ans que nous sommes là</li>
+        <li><strong>ventan / ven lanné</strong> : vingt ans</li>
+        <li><strong>an dézyèm fi</strong> : une deuxième fille</li>
+        <li><strong>Pyè kouri sé dé prèmyé fwa-a</strong> : Pierre a couru les deux premières fois</li>
+      </ul>
+      <p>Des expressions comme <strong>lo</strong>, <strong>tèlman</strong>, <strong>an étsétéra</strong>, <strong>ti bren</strong> servent aussi à quantifier, parfois par antiphrase.</p>
     </section>
   </main>
 

--- a/module-4.html
+++ b/module-4.html
@@ -127,7 +127,7 @@
       outline: none;
     }
 
-    .module-link.is-current {
+    .module-link[aria-current="page"] {
       background: rgba(139, 92, 246, 0.32);
       color: white;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
@@ -253,39 +253,6 @@
       outline: none;
     }
 
-    @media (max-width: 720px) {
-      .lesson-nav {
-        justify-content: center;
-        text-align: center;
-      }
-
-      .module-links {
-        justify-content: center;
-      }
-
-      .menu {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-      }
-
-      .menu-panel {
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-      }
-    }
-
-    @media (prefers-color-scheme: dark) {
-      nav {
-        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
-      }
-
-      footer p {
-        background: rgba(30, 17, 52, 0.62);
-      }
-    }
-
     main {
       padding: 3rem 1.5rem 4.5rem;
       max-width: 1100px;
@@ -310,95 +277,68 @@
       margin-bottom: 0.75rem;
     }
 
-    h3 {
-      color: var(--muted);
-      margin-bottom: 0.6rem;
-      font-size: 1.05rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
     p {
       margin: 0.6rem 0;
     }
 
-    ul,
-    ol {
-      margin: 0.75rem 0 0.75rem 1.25rem;
-      padding: 0;
-    }
-
-    li {
-      margin-bottom: 0.45rem;
-    }
-
-    .module-card .module-lessons {
-      list-style: none;
-      margin: 1.1rem 0 1.6rem;
-      padding: 0;
+    .module-card {
       display: grid;
-      gap: 0.5rem;
+      gap: 1.1rem;
     }
 
-    .module-card .module-lessons li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.55);
-      padding: 0.75rem 1rem;
-      border-radius: 16px;
-      font-weight: 600;
-      color: var(--accent-strong);
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
-    }
-
-    .examples {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 0.75rem;
-      margin: 1rem 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .examples li {
-      background: rgba(139, 92, 246, 0.12);
-      border-left: 4px solid rgba(139, 92, 246, 0.85);
-      padding: 0.9rem 1.1rem;
-      border-radius: 14px;
+    .module-card p {
       margin: 0;
-      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
     }
 
-    .note {
-      background: rgba(250, 204, 21, 0.18);
-      border-left: 4px solid #facc15;
-      padding: 0.85rem 1.1rem;
-      border-radius: 14px;
-      margin: 1.2rem 0;
+    .module-lessons {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .module-lessons a {
+      text-decoration: none;
       color: inherit;
-      box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.12);
-    }
-
-    .module-cta {
+      font-weight: 600;
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      padding: 0.75rem 1.4rem;
-      border-radius: 999px;
-      background: linear-gradient(135deg, rgba(139, 92, 246, 0.9), rgba(56, 189, 248, 0.75));
-      color: white;
+    }
+
+    .module-lessons a::before {
+      content: "→";
+      color: var(--accent-strong);
+      font-weight: 700;
+    }
+
+    .module-card-link {
+      justify-self: start;
       text-decoration: none;
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.85), rgba(56, 189, 248, 0.75));
+      color: white;
       font-weight: 600;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+      padding: 0.85rem 1.4rem;
+      border-radius: 999px;
       box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .module-cta:hover,
-    .module-cta:focus-visible {
+    .module-card-link:hover,
+    .module-card-link:focus-visible {
       transform: translateY(-2px);
       box-shadow: 0 22px 40px rgba(80, 56, 160, 0.36);
       outline: none;
+    }
+
+    .module-card small {
+      color: var(--muted);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
 
     footer {
@@ -420,25 +360,61 @@
       backdrop-filter: blur(16px);
       box-shadow: 0 12px 30px var(--shadow);
     }
+
+    @media (max-width: 720px) {
+      .lesson-nav {
+        justify-content: center;
+      }
+
+      .module-links {
+        justify-content: center;
+      }
+
+      .menu {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+      }
+
+      .menu-panel {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+      }
+
+      .module-card-link {
+        justify-self: center;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      nav {
+        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
+      }
+
+      footer p {
+        background: rgba(30, 17, 52, 0.62);
+      }
+    }
   </style>
 </head>
 <body>
-  <header>
+<header>
     <h1>Grammaire Martiniquaise</h1>
-    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en leçons pour accompagner vos exercices et révisions.</p>
+    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en modules thématiques pour accomp
+agner vos exercices et révisions.</p>
   </header>
-
-  <nav aria-label="Navigation des leçons">
+  <nav aria-label="Navigation principale">
     <div class="lesson-nav">
-      <div class="module-links" role="list">
-        <a class="module-link" href="index.html" role="listitem">Sommaire</a>
-        <a class="module-link" href="module-1.html" role="listitem">Module 1</a>
-        <a class="module-link" href="module-2.html" role="listitem">Module 2</a>
-        <a class="module-link" href="module-3.html" role="listitem">Module 3</a>
-        <a class="module-link is-current" href="module-4.html" role="listitem" aria-current="page">Module 4</a>
+      <div class="module-links">
+        <a class="module-link" href="index.html">Accueil</a>
+        <a class="module-link" href="module-1.html">Module 1</a>
+        <a class="module-link" href="module-2.html">Module 2</a>
+        <a class="module-link" href="module-3.html">Module 3</a>
+        <a class="module-link" href="module-4.html" aria-current="page">Module 4</a>
       </div>
       <details class="menu">
-        <summary class="menu-toggle">
+        <summary class="menu-toggle" aria-expanded="false">
           Sommaire du module
           <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
@@ -446,7 +422,7 @@
         </summary>
         <div class="menu-panel">
           <div class="menu-group">
-            <p class="menu-group-title">Module 4 · Structures nominales et quantification</p>
+            <p class="menu-group-title">Leçons 25 à 32</p>
             <ul>
               <li><a href="#lesson-25">Les usages de « sé »</a></li>
               <li><a href="#lesson-26">Le nom commun</a></li>
@@ -464,126 +440,137 @@
   </nav>
   <main>
     <section id="lesson-25">
-      <h2>Les usages de « sé »</h2>
-      <p><strong>sé</strong> possède quatre fonctions : présentatif (« c’est »), marque du pluriel défini, copule équivalente à « être » et optatif (conditionnel). Plusieurs occurrences peuvent cohabiter dans une même phrase.</p>
-      <ul class="examples">
-        <li><strong>sa, sé ki bagay ?</strong> : ça, qu’est-ce que c’est ?</li>
-        <li><strong>sé zanmi’w la</strong> : tes amis</li>
-        <li><strong>ou sé an salop</strong> : tu es un salaud</li>
-        <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
-      </ul>
-    </section>
+          <h2>Les usages de « sé »</h2>
+          <p><strong>sé</strong> possède quatre fonctions : présentatif (« c’est »), marque du pluriel défini, copule équivalente à « être » et optatif (conditionnel). Plusieurs occurrences peuvent cohabiter dans une même phrase.</p>
+          <ul class="examples">
+            <li><strong>sa, sé ki bagay ?</strong> : ça, qu’est-ce que c’est ?</li>
+            <li><strong>sé zanmi’w la</strong> : tes amis</li>
+            <li><strong>ou sé an salop</strong> : tu es un salaud</li>
+            <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
+          </ul>
+        </section>
 
     <section id="lesson-26">
-      <h2>Le nom commun</h2>
-      <p>Les noms peuvent apparaître sans article lorsqu’ils ont une valeur générique. Certains adjectifs ou verbes se nominalisent, souvent avec les préfixes <strong>la-</strong> ou <strong>le-</strong> pour les notions abstraites.</p>
-      <ul class="examples">
-        <li><strong>loto pa pou vini la</strong> : les voitures ne doivent pas venir ici</li>
-        <li><strong>lajistis sé an bon bagay</strong> : la justice est une bonne chose</li>
-        <li><strong>dòmi dous</strong> : c’est bon de dormir</li>
-        <li><strong>i fè an kay pa gran</strong> : il a construit une maison pas grande</li>
-      </ul>
-    </section>
+          <h2>Le nom commun</h2>
+          <p>Les noms peuvent apparaître sans article lorsqu’ils ont une valeur générique. Certains adjectifs ou verbes se nominalisent, souvent avec les préfixes <strong>la-</strong> ou <strong>le-</strong> pour les notions abstraites.</p>
+          <ul class="examples">
+            <li><strong>loto pa pou vini la</strong> : les voitures ne doivent pas venir ici</li>
+            <li><strong>lajistis sé an bon bagay</strong> : la justice est une bonne chose</li>
+            <li><strong>dòmi dous</strong> : c’est bon de dormir</li>
+            <li><strong>i fè an kay pa gran</strong> : il a construit une maison pas grande</li>
+          </ul>
+        </section>
 
     <section id="lesson-27">
-      <h2>Noms propres, titres et adresses</h2>
-      <p>Les noms propres peuvent recevoir l’article pour marquer la distance. Les titres et formules d’adresse varient selon le registre : <strong>misyé</strong>, <strong>manzè</strong>, <strong>mésyédanm</strong>, <strong>monchè</strong>, etc. Les noms de pays utilisent des prépositions spécifiques.</p>
-      <ul class="examples">
-        <li><strong>Misiyé Pòl la</strong> : ce Monsieur Paul</li>
-        <li><strong>mésyédanm</strong> : Mesdames et messieurs</li>
-        <li><strong>man dirèktris la konprann...</strong> : cette directrice pense…</li>
-        <li><strong>yo ka soti an Frans</strong> : ils viennent de France</li>
-      </ul>
-    </section>
+          <h2>Noms propres, titres et adresses</h2>
+          <p>Les noms propres peuvent recevoir l’article pour marquer la distance. Les titres et formules d’adresse varient selon le registre : <strong>misyé</strong>, <strong>manzè</strong>, <strong>mésyédanm</strong>, <strong>monchè</strong>, etc. Les noms de pays utilisent des prépositions spécifiques.</p>
+          <ul class="examples">
+            <li><strong>Misiyé Pòl la</strong> : ce Monsieur Paul</li>
+            <li><strong>mésyédanm</strong> : Mesdames et messieurs</li>
+            <li><strong>man dirèktris la konprann...</strong> : cette directrice pense…</li>
+            <li><strong>yo ka soti an Frans</strong> : ils viennent de France</li>
+          </ul>
+        </section>
 
     <section id="lesson-28">
-      <h2>L’adjectif</h2>
-      <p>De nombreux adjectifs résultent de relatives réduites ou de syntagmes nominalisés. Certains intensifs (<strong>bidim</strong>, <strong>manman</strong>) ou diminutifs (<strong>ti monyonyon</strong>) précèdent le nom. Le genre grammatical n’est pas marqué, mais des suffixes (<strong>-èz</strong>) peuvent souligner le féminin sémantique.</p>
-      <ul class="examples">
-        <li><strong>an boug vayan</strong> : un homme courageux</li>
-        <li><strong>an ti monyonyon pen</strong> : un tout petit bout de pain</li>
-        <li><strong>fanm ganmé a</strong> : la femme élégante</li>
-        <li><strong>Pyè, sé an boug blip</strong> : Pierre est un type mal dégrossi</li>
-      </ul>
-      <div class="note">Attention aux ambiguïtés : <strong>fanm kouyon an</strong> = la femme idiote ; <strong>fanm kouyon-an</strong> = la femme de l’idiot.</div>
-    </section>
+          <h2>L’adjectif</h2>
+          <p>De nombreux adjectifs résultent de relatives réduites ou de syntagmes nominalisés. Certains intensifs (<strong>bidim</strong>, <strong>manman</strong>) ou diminutifs (<strong>ti monyonyon</strong>) précèdent le nom. Le genre grammatical n’est pas marqué, mais des suffixes (<strong>-èz</strong>) peuvent souligner le féminin sémantique.</p>
+          <ul class="examples">
+            <li><strong>an boug vayan</strong> : un homme courageux</li>
+            <li><strong>an ti monyonyon pen</strong> : un tout petit bout de pain</li>
+            <li><strong>fanm ganmé a</strong> : la femme élégante</li>
+            <li><strong>Pyè, sé an boug blip</strong> : Pierre est un type mal dégrossi</li>
+          </ul>
+          <div class="note">Attention aux ambiguïtés : <strong>fanm kouyon an</strong> = la femme idiote ; <strong>fanm kouyon-an</strong> = la femme de l’idiot.</div>
+        </section>
 
     <section id="lesson-29">
-      <h2>Le comparatif</h2>
-      <p>La supériorité se marque avec <strong>pli… ki/pasé</strong>, l’égalité avec <strong>osi… ki</strong> ou <strong>otan… otan</strong>, l’infériorité avec <strong>mwen(s)… ki</strong>. Des adverbes (<strong>titak</strong>, <strong>anpil</strong>, <strong>lontan</strong>) modulant l’intensité.</p>
-      <ul class="examples">
-        <li><strong>Pyè pli sòt ki Wobè</strong> : Pierre est plus bête que Robert</li>
-        <li><strong>Féfé osi gwo ki Pyè</strong> : Féfé est aussi gros que Pierre</li>
-        <li><strong>mwen gran ki Pyè</strong> : moins grand que Pierre</li>
-        <li><strong>pli ou ké dòmi, pli ou ké anvi dòmi</strong> : plus tu dormiras, plus tu auras envie de dormir</li>
-      </ul>
-    </section>
+          <h2>Le comparatif</h2>
+          <p>La supériorité se marque avec <strong>pli… ki/pasé</strong>, l’égalité avec <strong>osi… ki</strong> ou <strong>otan… otan</strong>, l’infériorité avec <strong>mwen(s)… ki</strong>. Des adverbes (<strong>titak</strong>, <strong>anpil</strong>, <strong>lontan</strong>) modulant l’intensité.</p>
+          <ul class="examples">
+            <li><strong>Pyè pli sòt ki Wobè</strong> : Pierre est plus bête que Robert</li>
+            <li><strong>Féfé osi gwo ki Pyè</strong> : Féfé est aussi gros que Pierre</li>
+            <li><strong>mwen gran ki Pyè</strong> : moins grand que Pierre</li>
+            <li><strong>pli ou ké dòmi, pli ou ké anvi dòmi</strong> : plus tu dormiras, plus tu auras envie de dormir</li>
+          </ul>
+        </section>
 
     <section id="lesson-30">
-      <h2>Le superlatif</h2>
-      <p>Le superlatif relatif s’appuie sur <strong>pli</strong> ou <strong>mwen</strong> associés à l’article (<strong>sé… a</strong> pour le particulier, <strong>lé</strong> pour le général). Le superlatif absolu se forme par redoublement, particules intensives ou adjectifs comme <strong>bon</strong>, <strong>bèl</strong>, <strong>gwo</strong>, <strong>tou</strong>.</p>
-      <ul class="examples">
-        <li><strong>boug mwen pyétè a</strong> : le type le moins avare</li>
-        <li><strong>Pyè, sé boug pli séryé man konnèt</strong> : Pierre est le type le plus sérieux que je connaisse</li>
-        <li><strong>nou wè an bèl bèl fanm</strong> : nous avons vu une très belle femme</li>
-        <li><strong>i tou kagou</strong> : il est très malade</li>
-      </ul>
-    </section>
+          <h2>Le superlatif</h2>
+          <p>Le superlatif relatif s’appuie sur <strong>pli</strong> ou <strong>mwen</strong> associés à l’article (<strong>sé… a</strong> pour le particulier, <strong>lé</strong> pour le général). Le superlatif absolu se forme par redoublement, particules intensives ou adjectifs comme <strong>bon</strong>, <strong>bèl</strong>, <strong>gwo</strong>, <strong>tou</strong>.</p>
+          <ul class="examples">
+            <li><strong>boug mwen pyétè a</strong> : le type le moins avare</li>
+            <li><strong>Pyè, sé boug pli séryé man konnèt</strong> : Pierre est le type le plus sérieux que je connaisse</li>
+            <li><strong>nou wè an bèl bèl fanm</strong> : nous avons vu une très belle femme</li>
+            <li><strong>i tou kagou</strong> : il est très malade</li>
+          </ul>
+        </section>
 
     <section id="lesson-31">
-      <h2>Quantification et numération (I)</h2>
-      <p>Les adverbes/adjectifs de quantité incluent <strong>tout</strong>, <strong>chak</strong>, <strong>tjèk</strong>, <strong>yonndé</strong>, <strong>anpil</strong>, <strong>anlo</strong>, <strong>lòt</strong>, <strong>menm</strong>, <strong>kalté</strong>. Ils modulent la portée du nom selon qu’il est défini ou indéfini.</p>
-      <ul class="examples">
-        <li><strong>tout moun</strong> : tout le monde</li>
-        <li><strong>chak moun palé</strong> : chacun a parlé</li>
-        <li><strong>ni tjèk sé moun-la</strong> : il y a quelques-unes de ces personnes</li>
-        <li><strong>man pa enmen kalté moun-tala</strong> : je n’aime pas ce genre de personne</li>
-      </ul>
-    </section>
+          <h2>Quantification et numération (I)</h2>
+          <p>Les adverbes/adjectifs de quantité incluent <strong>tout</strong>, <strong>chak</strong>, <strong>tjèk</strong>, <strong>yonndé</strong>, <strong>anpil</strong>, <strong>anlo</strong>, <strong>lòt</strong>, <strong>menm</strong>, <strong>kalté</strong>. Ils modulent la portée du nom selon qu’il est défini ou indéfini.</p>
+          <ul class="examples">
+            <li><strong>tout moun</strong> : tout le monde</li>
+            <li><strong>chak moun palé</strong> : chacun a parlé</li>
+            <li><strong>ni tjèk sé moun-la</strong> : il y a quelques-unes de ces personnes</li>
+            <li><strong>man pa enmen kalté moun-tala</strong> : je n’aime pas ce genre de personne</li>
+          </ul>
+        </section>
 
     <section id="lesson-32">
-      <h2>Quantification et numération (II)</h2>
-      <p>Les numéraux cardinaux (yonn, dé, twa…) et ordinaux (prèmyé, dézyèm…) suivent des règles spécifiques. Certains servent d’intensif. Les expressions de durée ou de fréquence s’appuient sur ces formes.</p>
-      <ul class="examples">
-        <li><strong>ni dé lanné nou la</strong> : cela fait deux ans que nous sommes là</li>
-        <li><strong>ventan / ven lanné</strong> : vingt ans</li>
-        <li><strong>an dézyèm fi</strong> : une deuxième fille</li>
-        <li><strong>Pyè kouri sé dé prèmyé fwa-a</strong> : Pierre a couru les deux premières fois</li>
-      </ul>
-      <p>Des expressions comme <strong>lo</strong>, <strong>tèlman</strong>, <strong>an étsétéra</strong>, <strong>ti bren</strong> servent aussi à quantifier, parfois par antiphrase.</p>
-    </section>
+          <h2>Quantification et numération (II)</h2>
+          <p>Les numéraux cardinaux (yonn, dé, twa…) et ordinaux (prèmyé, dézyèm…) suivent des règles spécifiques. Certains servent d’intensif. Les expressions de durée ou de fréquence s’appuient sur ces formes.</p>
+          <ul class="examples">
+            <li><strong>ni dé lanné nou la</strong> : cela fait deux ans que nous sommes là</li>
+            <li><strong>ventan / ven lanné</strong> : vingt ans</li>
+            <li><strong>an dézyèm fi</strong> : une deuxième fille</li>
+            <li><strong>Pyè kouri sé dé prèmyé fwa-a</strong> : Pierre a couru les deux premières fois</li>
+          </ul>
+          <p>Des expressions comme <strong>lo</strong>, <strong>tèlman</strong>, <strong>an étsétéra</strong>, <strong>ti bren</strong> servent aussi à quantifier, parfois par antiphrase.</p>
+        </section>
   </main>
-
-  <footer>
-    <p>Mise à jour des règles grammaticales pour accompagner les exercices de créole martiniquais.</p>
+<footer>
+    <p>Travail collaboratif · Merci à tou·te·s les contributrices et contributeurs !</p>
   </footer>
+<script>
+    const menus = document.querySelectorAll('details.menu');
 
-  <script>
-    const menu = document.querySelector('.menu');
+    menus.forEach((menu) => {
+      const summary = menu.querySelector('summary');
+      const links = menu.querySelectorAll('a');
 
-    if (menu) {
-      const panel = menu.querySelector('.menu-panel');
+      if (summary) {
+        summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        menu.addEventListener('toggle', () => {
+          summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        });
+      }
 
-      panel?.addEventListener('click', (event) => {
-        const link = event.target.closest('a');
-        if (link) {
+      links.forEach((link) => {
+        link.addEventListener('click', () => {
           menu.removeAttribute('open');
-        }
+        });
       });
+    });
 
-      document.addEventListener('click', (event) => {
+    document.addEventListener('click', (event) => {
+      menus.forEach((menu) => {
         if (!menu.contains(event.target)) {
           menu.removeAttribute('open');
         }
       });
+    });
 
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-          menu.removeAttribute('open');
-          menu.querySelector('summary')?.focus();
-        }
-      });
-    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        menus.forEach((menu) => {
+          if (menu.open) {
+            menu.removeAttribute('open');
+            menu.querySelector('summary')?.focus();
+          }
+        });
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the lesson dropdown with module links and a reusable summary panel
- move the 32 lesson sections into four dedicated module-* pages while leaving cards on the homepage
- add a shared script to close the summary menu when interacting outside or following a link

## Testing
- not run (static HTML changes)

------
https://chatgpt.com/codex/tasks/task_e_68dbee0cc294832eb734d8674ae44451